### PR TITLE
Fixes-#35-Constant-variables-(with-RHS-=-0)-are-not-scaled-properly

### DIFF
--- a/src/OSPSuite.SimModel/include/SimModel/BooleanFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/BooleanFormula.h
@@ -41,7 +41,7 @@ class BooleanFormula :
 
 		virtual void UpdateIndicesOfReferencedVariables();
 		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+		virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 };
 
 class AndFormula : 	

--- a/src/OSPSuite.SimModel/include/SimModel/BooleanFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/BooleanFormula.h
@@ -40,6 +40,8 @@ class BooleanFormula :
 		void BooleanFormula::SwitchFormulaFromComparisonFormula(std::vector<Formula*> &vecExplicit, std::vector<Formula*> &vecImplicit);
 
 		virtual void UpdateIndicesOfReferencedVariables();
+		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 };
 
 class AndFormula : 	

--- a/src/OSPSuite.SimModel/include/SimModel/ConstantFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/ConstantFormula.h
@@ -39,6 +39,8 @@ class ConstantFormula :
 		virtual void AppendUsedParameters(std::set<int> & usedParameterIDs);
 
 		virtual void UpdateIndicesOfReferencedVariables();
+		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/ConstantFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/ConstantFormula.h
@@ -40,7 +40,7 @@ class ConstantFormula :
 
 		virtual void UpdateIndicesOfReferencedVariables();
 		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+		virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/DiffFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/DiffFormula.h
@@ -36,6 +36,8 @@ class DiffFormula :
 		virtual void AppendUsedParameters(std::set<int> & usedParameterIDs);
 
 		virtual void UpdateIndicesOfReferencedVariables();
+		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/DiffFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/DiffFormula.h
@@ -37,7 +37,7 @@ class DiffFormula :
 
 		virtual void UpdateIndicesOfReferencedVariables();
 		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+		virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/DivFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/DivFormula.h
@@ -35,6 +35,8 @@ class DivFormula :
 		virtual void AppendUsedParameters(std::set<int> & usedParameterIDs);
 
 		virtual void UpdateIndicesOfReferencedVariables();
+		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/DivFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/DivFormula.h
@@ -36,7 +36,7 @@ class DivFormula :
 
 		virtual void UpdateIndicesOfReferencedVariables();
 		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+		virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/ExplicitFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/ExplicitFormula.h
@@ -78,6 +78,8 @@ public:
 	virtual void AppendUsedParameters(std::set<int> & usedParameterIDs);
 
 	virtual void UpdateIndicesOfReferencedVariables();
+	//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+	virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 };
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/include/SimModel/ExplicitFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/ExplicitFormula.h
@@ -79,7 +79,7 @@ public:
 
 	virtual void UpdateIndicesOfReferencedVariables();
 	//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-	virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+	virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 };
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/include/SimModel/Formula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/Formula.h
@@ -103,6 +103,8 @@ public:
 
 	//Change indices of referenced variables according to the given indices permutation
 	virtual void UpdateIndicesOfReferencedVariables() = 0;
+	//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+	virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor) = 0;
 
 protected:
 	virtual bool UseBracketsForODESystemGeneration ();

--- a/src/OSPSuite.SimModel/include/SimModel/Formula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/Formula.h
@@ -104,7 +104,7 @@ public:
 	//Change indices of referenced variables according to the given indices permutation
 	virtual void UpdateIndicesOfReferencedVariables() = 0;
 	//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-	virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor) = 0;
+	virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor) = 0;
 
 protected:
 	virtual bool UseBracketsForODESystemGeneration ();

--- a/src/OSPSuite.SimModel/include/SimModel/IfFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/IfFormula.h
@@ -38,6 +38,8 @@ class IfFormula :
 		virtual void AppendUsedParameters(std::set<int> & usedParameterIDs);
 
 		virtual void UpdateIndicesOfReferencedVariables();
+		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/IfFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/IfFormula.h
@@ -39,7 +39,7 @@ class IfFormula :
 
 		virtual void UpdateIndicesOfReferencedVariables();
 		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+		virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/MaxFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/MaxFormula.h
@@ -35,7 +35,7 @@ class MaxFormula :
 
 		virtual void UpdateIndicesOfReferencedVariables();
 		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+		virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/MaxFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/MaxFormula.h
@@ -34,6 +34,8 @@ class MaxFormula :
 		virtual void AppendUsedParameters(std::set<int> & usedParameterIDs);
 
 		virtual void UpdateIndicesOfReferencedVariables();
+		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/MinFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/MinFormula.h
@@ -34,6 +34,8 @@ class MinFormula :
 		virtual void AppendUsedParameters(std::set<int> & usedParameterIDs);
 
 		virtual void UpdateIndicesOfReferencedVariables();
+		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/MinFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/MinFormula.h
@@ -35,7 +35,7 @@ class MinFormula :
 
 		virtual void UpdateIndicesOfReferencedVariables();
 		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+		virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/ParameterFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/ParameterFormula.h
@@ -45,7 +45,7 @@ class ParameterFormula :
 
 		virtual void UpdateIndicesOfReferencedVariables();
 		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+		virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/ParameterFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/ParameterFormula.h
@@ -44,6 +44,8 @@ class ParameterFormula :
 		virtual void InsertNewParameters(std::map<std::string, ParameterFormula *> & mapNewP);
 
 		virtual void UpdateIndicesOfReferencedVariables();
+		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/PowerFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/PowerFormula.h
@@ -37,7 +37,7 @@ class PowerFormula :
 
 		virtual void UpdateIndicesOfReferencedVariables();
 		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+		virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/PowerFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/PowerFormula.h
@@ -36,6 +36,8 @@ class PowerFormula :
 		virtual void AppendUsedParameters(std::set<int> & usedParameterIDs);
 
 		virtual void UpdateIndicesOfReferencedVariables();
+		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/ProductFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/ProductFormula.h
@@ -35,6 +35,8 @@ class ProductFormula :
 		virtual void AppendUsedParameters(std::set<int> & usedParameterIDs);
 
 		virtual void UpdateIndicesOfReferencedVariables();
+		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/ProductFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/ProductFormula.h
@@ -36,7 +36,7 @@ class ProductFormula :
 
 		virtual void UpdateIndicesOfReferencedVariables();
 		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+		virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/Quantity.h
+++ b/src/OSPSuite.SimModel/include/SimModel/Quantity.h
@@ -151,7 +151,7 @@ public:
 
 	virtual void UpdateIndicesOfReferencedVariables();
 	//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this quantity.
-	virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+	virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 };
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/include/SimModel/Quantity.h
+++ b/src/OSPSuite.SimModel/include/SimModel/Quantity.h
@@ -150,6 +150,8 @@ public:
 	void AppendUsedParameters(std::set<int> & usedParameterIDs);
 
 	virtual void UpdateIndicesOfReferencedVariables();
+	//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this quantity.
+	virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 };
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/include/SimModel/QuantityReference.h
+++ b/src/OSPSuite.SimModel/include/SimModel/QuantityReference.h
@@ -75,7 +75,7 @@ public:
 
 	virtual void UpdateIndicesOfReferencedVariables();
 	//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-	virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+	virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 };
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/include/SimModel/QuantityReference.h
+++ b/src/OSPSuite.SimModel/include/SimModel/QuantityReference.h
@@ -74,6 +74,8 @@ public:
 	void AppendUsedParameters(std::set<int> & usedParameterIDs);
 
 	virtual void UpdateIndicesOfReferencedVariables();
+	//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+	virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 };
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/include/SimModel/SimpleProductFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/SimpleProductFormula.h
@@ -43,7 +43,7 @@ class SimpleProductFormula :
 
 		virtual void UpdateIndicesOfReferencedVariables();
 		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+		virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/SimpleProductFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/SimpleProductFormula.h
@@ -42,6 +42,8 @@ class SimpleProductFormula :
 		virtual void AppendUsedParameters(std::set<int> & usedParameterIDs);
 
 		virtual void UpdateIndicesOfReferencedVariables();
+		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/Simulation.h
+++ b/src/OSPSuite.SimModel/include/SimModel/Simulation.h
@@ -149,7 +149,7 @@ public:
 
 	SIM_EXPORT OutputSchema & GetOutputSchema();
 
-	void RedimAndInitValues (int numberOfTimePoints, double * speciesInitialValuesScaled);
+	void RedimAndInitValues(int numberOfTimePoints, double * speciesInitialValuesScaled, double * speciesInitialValuesUnscaled);
 
 	//replace formulas with values where possible
 	void SimplifyObjects(bool forCurrentRunOnly);

--- a/src/OSPSuite.SimModel/include/SimModel/Species.h
+++ b/src/OSPSuite.SimModel/include/SimModel/Species.h
@@ -19,8 +19,8 @@ class Species :
 {
 protected:
 	TObjectList<Formula> _rhsFormulaList;
-	//List of all formulas that have a reference to this species.
-	TObjectList<Formula> _allFormulaList;
+	//A vector of all formulas that have a reference to this species.
+	std::vector<Formula*> _allFormulaVector;
 	double m_ODEScaleFactor;
 	double _DEScaleFactorInv; //inverse of scale factor
 	int m_ODEIndex;

--- a/src/OSPSuite.SimModel/include/SimModel/Species.h
+++ b/src/OSPSuite.SimModel/include/SimModel/Species.h
@@ -19,12 +19,14 @@ class Species :
 {
 protected:
 	TObjectList<Formula> _rhsFormulaList;
+	//List of all formulas that have a reference to this species.
+	TObjectList<Formula> _allFormulaList;
 	double m_ODEScaleFactor;
 	double _DEScaleFactorInv; //inverse of scale factor
 	int m_ODEIndex;
 	int _rhsFormulaListSize;
 	double _simulationStartTime; //used just for check during getting species value
-	
+	int _allFormulaListSize;
 	std::string getFormulaXMLAttributeName();
 	
 	//number of DE-Variables used in the RHS of given variable
@@ -69,7 +71,7 @@ public:
 
 	//set all species values = species initial value
 	//(for species constant during simulation)
-	void FillWithInitialValue(const double * speciesInitialValuesScaled);
+	void FillWithInitialValue(const double * speciesInitialValuesUnscaled);
 
 	//rescale back (division by DE scale factor)
 	void RescaleValues ();
@@ -111,6 +113,11 @@ public:
     // -lowerHalfBandWidth <= j-i <= upperHalfBandWidth
 	// (where i is the ODE index of the current variable)
 	void GetRHSUsedBandRange(int & upperHalfBandWidth, int & lowerHalfBandWidth);
+
+	/*
+	Add the given formula to the list of formulas that use this species.
+	*/
+	void AddFormulaReference(Formula * formula);
 
 	bool NegativeValuesAllowed(void);
 };

--- a/src/OSPSuite.SimModel/include/SimModel/SumFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/SumFormula.h
@@ -36,7 +36,7 @@ class SumFormula :
 
 		virtual void UpdateIndicesOfReferencedVariables();
 		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+		virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/SumFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/SumFormula.h
@@ -35,6 +35,8 @@ class SumFormula :
 		virtual void AppendUsedParameters(std::set<int> & usedParameterIDs);
 
 		virtual void UpdateIndicesOfReferencedVariables();
+		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/TableFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/TableFormula.h
@@ -68,6 +68,8 @@ public:
 	virtual void AppendUsedParameters(std::set<int> & usedParameterIDs);
 
 	virtual void UpdateIndicesOfReferencedVariables();
+	//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+	virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 
 	void SetUseDerivedValues(bool useDerivedValues);
 	bool UseDerivedValues();

--- a/src/OSPSuite.SimModel/include/SimModel/TableFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/TableFormula.h
@@ -69,7 +69,7 @@ public:
 
 	virtual void UpdateIndicesOfReferencedVariables();
 	//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-	virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+	virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 
 	void SetUseDerivedValues(bool useDerivedValues);
 	bool UseDerivedValues();

--- a/src/OSPSuite.SimModel/include/SimModel/TableFormulaWithOffset.h
+++ b/src/OSPSuite.SimModel/include/SimModel/TableFormulaWithOffset.h
@@ -63,6 +63,8 @@ public:
 	virtual void AppendUsedParameters(std::set<int> & usedParameterIDs);
 
 	virtual void UpdateIndicesOfReferencedVariables();
+	//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+	virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 };
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/include/SimModel/TableFormulaWithOffset.h
+++ b/src/OSPSuite.SimModel/include/SimModel/TableFormulaWithOffset.h
@@ -64,7 +64,7 @@ public:
 
 	virtual void UpdateIndicesOfReferencedVariables();
 	//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-	virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+	virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 };
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/include/SimModel/TableFormulaWithXArgument.h
+++ b/src/OSPSuite.SimModel/include/SimModel/TableFormulaWithXArgument.h
@@ -63,6 +63,8 @@ public:
 	virtual void AppendUsedParameters(std::set<int> & usedParameterIDs);
 
 	virtual void UpdateIndicesOfReferencedVariables();
+	//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+	virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 };
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/include/SimModel/TableFormulaWithXArgument.h
+++ b/src/OSPSuite.SimModel/include/SimModel/TableFormulaWithXArgument.h
@@ -64,7 +64,7 @@ public:
 
 	virtual void UpdateIndicesOfReferencedVariables();
 	//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-	virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+	virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 };
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/include/SimModel/UnaryFunctionFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/UnaryFunctionFormula.h
@@ -45,7 +45,7 @@ class UnaryFunctionFormula :
 
 		virtual void UpdateIndicesOfReferencedVariables();
 		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+		virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/UnaryFunctionFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/UnaryFunctionFormula.h
@@ -44,6 +44,8 @@ class UnaryFunctionFormula :
 		virtual void AppendUsedParameters(std::set<int> & usedParameterIDs);
 
 		virtual void UpdateIndicesOfReferencedVariables();
+		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/VariableFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/VariableFormula.h
@@ -40,7 +40,7 @@ class VariableFormula :
 
 		virtual void UpdateIndicesOfReferencedVariables();
 		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
-		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
+		virtual void UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/include/SimModel/VariableFormula.h
+++ b/src/OSPSuite.SimModel/include/SimModel/VariableFormula.h
@@ -39,6 +39,8 @@ class VariableFormula :
 		virtual void AppendUsedParameters(std::set<int> & usedParameterIDs);
 
 		virtual void UpdateIndicesOfReferencedVariables();
+		//Update the value to ODEScaleFactor of the scale factor of the variable with the id referenced by this formula.
+		virtual void UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor);
 	
 	protected:
 		virtual void WriteFormulaMatlabCode (std::ostream & mrOut);

--- a/src/OSPSuite.SimModel/src/BooleanFormula.cpp
+++ b/src/OSPSuite.SimModel/src/BooleanFormula.cpp
@@ -263,6 +263,14 @@ void BooleanFormula::UpdateIndicesOfReferencedVariables()
 		m_SecondOperandFormula->UpdateIndicesOfReferencedVariables();
 }
 
+void BooleanFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	m_FirstOperandFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+
+	if (m_SecondOperandFormula)
+		m_SecondOperandFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+}
+
 //-------------------------------------------------------------------
 //---- And (A&&B)
 //-------------------------------------------------------------------

--- a/src/OSPSuite.SimModel/src/BooleanFormula.cpp
+++ b/src/OSPSuite.SimModel/src/BooleanFormula.cpp
@@ -263,12 +263,12 @@ void BooleanFormula::UpdateIndicesOfReferencedVariables()
 		m_SecondOperandFormula->UpdateIndicesOfReferencedVariables();
 }
 
-void BooleanFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void BooleanFormula::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
-	m_FirstOperandFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	m_FirstOperandFormula->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
 
 	if (m_SecondOperandFormula)
-		m_SecondOperandFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+		m_SecondOperandFormula->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
 }
 
 //-------------------------------------------------------------------

--- a/src/OSPSuite.SimModel/src/ConstantFormula.cpp
+++ b/src/OSPSuite.SimModel/src/ConstantFormula.cpp
@@ -127,4 +127,9 @@ namespace SimModelNative
 		//nothing to do so far
 	}
 
+	void ConstantFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+	{
+		//nothing to do so far
+	}
+
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/ConstantFormula.cpp
+++ b/src/OSPSuite.SimModel/src/ConstantFormula.cpp
@@ -127,7 +127,7 @@ namespace SimModelNative
 		//nothing to do so far
 	}
 
-	void ConstantFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+	void ConstantFormula::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 	{
 		//nothing to do so far
 	}

--- a/src/OSPSuite.SimModel/src/DESolver.cpp
+++ b/src/OSPSuite.SimModel/src/DESolver.cpp
@@ -195,6 +195,7 @@ namespace SimModelNative
 
 		SimModelSolverBase * pSolver = NULL;  //pointer to new solver instance
 		double * initialvalues = NULL;        //(scaled) initial values of DE variables
+		double * initialvaluesUnscaled = NULL;        //unscaled initial values of DE variables
 		double * solution = NULL;             //solution vector of current problem
 		double * solutionAboveAbsTol = NULL;  //solution vector of current problem where all values in [-AbsTol..AbsTol] are set to zero
 		double ** sensitivityValues = NULL;   //sensitivity values for one time point [NumberOfUnknowns X NumberOfSensitivityParameters] 
@@ -224,9 +225,12 @@ namespace SimModelNative
 			//get scaled initial values for DE variables
 			initialvalues = _parentSim->GetDEInitialValuesScaled();
 
+			//get unscaled initial values
+			initialvaluesUnscaled = _parentSim->GetDEInitialValues();
+
 			//redim species/observers/time array of the simulation
 			_parentSim->RedimAndInitValues(numberOfSimulatedTimeSteps+1,
-				                           initialvalues); //+1 because of sim start time, 
+				                           initialvalues, initialvaluesUnscaled); //+1 because of sim start time, 
 			                                                       //which is not included in outputTimePoints
 
 			//---- cache DE variables arranged by their ODE Index
@@ -401,6 +405,8 @@ namespace SimModelNative
 			//---- clean up
 			delete[] initialvalues; 
 			initialvalues = NULL;
+			delete[] initialvaluesUnscaled;
+			initialvaluesUnscaled = NULL;
 			delete[] solution;
 			solution = NULL;
 			delete[] solutionAboveAbsTol;
@@ -420,7 +426,8 @@ namespace SimModelNative
 		}
 		catch(...)
 		{
-			if (initialvalues) delete[] initialvalues; 
+			if (initialvalues) delete[] initialvalues;
+			if (initialvaluesUnscaled) delete[] initialvaluesUnscaled;
 			if (solution) delete[] solution;
 			if(solutionAboveAbsTol) delete[] solutionAboveAbsTol;
 			if (m_ODEVariables) delete[] m_ODEVariables;

--- a/src/OSPSuite.SimModel/src/DiffFormula.cpp
+++ b/src/OSPSuite.SimModel/src/DiffFormula.cpp
@@ -184,5 +184,10 @@ void DiffFormula::UpdateIndicesOfReferencedVariables()
 	m_SubtrahendFormula->UpdateIndicesOfReferencedVariables();
 }
 
+void DiffFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	m_MinuendFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	m_SubtrahendFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+}
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/DiffFormula.cpp
+++ b/src/OSPSuite.SimModel/src/DiffFormula.cpp
@@ -184,10 +184,10 @@ void DiffFormula::UpdateIndicesOfReferencedVariables()
 	m_SubtrahendFormula->UpdateIndicesOfReferencedVariables();
 }
 
-void DiffFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void DiffFormula::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
-	m_MinuendFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
-	m_SubtrahendFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	m_MinuendFormula->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
+	m_SubtrahendFormula->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
 }
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/DivFormula.cpp
+++ b/src/OSPSuite.SimModel/src/DivFormula.cpp
@@ -214,10 +214,10 @@ void DivFormula::UpdateIndicesOfReferencedVariables()
 	m_DenominatorFormula->UpdateIndicesOfReferencedVariables();
 }
 
-void DivFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void DivFormula::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
-	m_NumeratorFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
-	m_DenominatorFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	m_NumeratorFormula->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
+	m_DenominatorFormula->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
 }
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/DivFormula.cpp
+++ b/src/OSPSuite.SimModel/src/DivFormula.cpp
@@ -214,4 +214,10 @@ void DivFormula::UpdateIndicesOfReferencedVariables()
 	m_DenominatorFormula->UpdateIndicesOfReferencedVariables();
 }
 
+void DivFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	m_NumeratorFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	m_DenominatorFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+}
+
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/ExplicitFormula.cpp
+++ b/src/OSPSuite.SimModel/src/ExplicitFormula.cpp
@@ -456,10 +456,10 @@ void ExplicitFormula::UpdateIndicesOfReferencedVariables()
 		_formula->UpdateIndicesOfReferencedVariables();
 }
 
-void ExplicitFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void ExplicitFormula::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
 	if (_formula != NULL)
-		_formula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+		_formula->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
 }
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/ExplicitFormula.cpp
+++ b/src/OSPSuite.SimModel/src/ExplicitFormula.cpp
@@ -363,6 +363,13 @@ void ExplicitFormula::Finalize()
 	for(int i =0; i<_quantityRefs.size(); i++)
 	{
 		QuantityReference * quantityRef = _quantityRefs[i];
+		//If the quantity is a species, add this formula to the list of formulas that use the species.
+		//Used for updating scale factors.
+		if (quantityRef->IsSpecies())
+		{
+			SimModelNative::Species * species = quantityRef->GetSpecies();
+			species->AddFormulaReference(this);
+		}
 
 		bool isDEVariable = (quantityRef->IsSpecies() && 
 			                !quantityRef->GetSpecies()->IsConstantDuringCalculation());
@@ -447,6 +454,12 @@ void ExplicitFormula::UpdateIndicesOfReferencedVariables()
 {
 	if (_formula != NULL)
 		_formula->UpdateIndicesOfReferencedVariables();
+}
+
+void ExplicitFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	if (_formula != NULL)
+		_formula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
 }
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/IfFormula.cpp
+++ b/src/OSPSuite.SimModel/src/IfFormula.cpp
@@ -288,4 +288,11 @@ void IfFormula::UpdateIndicesOfReferencedVariables()
 	m_ElseStatement->UpdateIndicesOfReferencedVariables();
 }
 
+void IfFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	m_IfStatement->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	m_ThenStatement->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	m_ElseStatement->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+}
+
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/IfFormula.cpp
+++ b/src/OSPSuite.SimModel/src/IfFormula.cpp
@@ -288,11 +288,11 @@ void IfFormula::UpdateIndicesOfReferencedVariables()
 	m_ElseStatement->UpdateIndicesOfReferencedVariables();
 }
 
-void IfFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void IfFormula::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
-	m_IfStatement->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
-	m_ThenStatement->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
-	m_ElseStatement->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	m_IfStatement->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
+	m_ThenStatement->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
+	m_ElseStatement->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
 }
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/MaxFormula.cpp
+++ b/src/OSPSuite.SimModel/src/MaxFormula.cpp
@@ -203,10 +203,10 @@ void MaxFormula::UpdateIndicesOfReferencedVariables()
 	m_SecondArgument->UpdateIndicesOfReferencedVariables();
 }
 
-void MaxFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void MaxFormula::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
-	m_FirstArgument->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
-	m_SecondArgument->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	m_FirstArgument->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
+	m_SecondArgument->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
 }
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/MaxFormula.cpp
+++ b/src/OSPSuite.SimModel/src/MaxFormula.cpp
@@ -203,4 +203,10 @@ void MaxFormula::UpdateIndicesOfReferencedVariables()
 	m_SecondArgument->UpdateIndicesOfReferencedVariables();
 }
 
+void MaxFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	m_FirstArgument->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	m_SecondArgument->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+}
+
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/MinFormula.cpp
+++ b/src/OSPSuite.SimModel/src/MinFormula.cpp
@@ -202,10 +202,10 @@ void MinFormula::UpdateIndicesOfReferencedVariables()
 	m_SecondArgument->UpdateIndicesOfReferencedVariables();
 }
 
-void MinFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void MinFormula::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
-	m_FirstArgument->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
-	m_SecondArgument->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	m_FirstArgument->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
+	m_SecondArgument->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
 }
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/MinFormula.cpp
+++ b/src/OSPSuite.SimModel/src/MinFormula.cpp
@@ -202,4 +202,10 @@ void MinFormula::UpdateIndicesOfReferencedVariables()
 	m_SecondArgument->UpdateIndicesOfReferencedVariables();
 }
 
+void MinFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	m_FirstArgument->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	m_SecondArgument->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+}
+
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/ParameterFormula.cpp
+++ b/src/OSPSuite.SimModel/src/ParameterFormula.cpp
@@ -245,9 +245,9 @@ void ParameterFormula::UpdateIndicesOfReferencedVariables()
 	_quantityRef.UpdateIndicesOfReferencedVariables();
 }
 
-void ParameterFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void ParameterFormula::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
-	_quantityRef.UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	_quantityRef.UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
 }
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/ParameterFormula.cpp
+++ b/src/OSPSuite.SimModel/src/ParameterFormula.cpp
@@ -100,7 +100,13 @@ Formula * ParameterFormula::RecursiveSimplify()
 
 void ParameterFormula::Finalize()
 {
-	//nothing to do 
+	//If the quantity is a species, add this formula to the list of formulas that use the species.
+	//Used for updating scale factors.
+	if (_quantityRef.IsSpecies())
+	{
+		SimModelNative::Species * species = _quantityRef.GetSpecies();
+		species->AddFormulaReference(this);
+	}
 }
 
 bool ParameterFormula::IsTime()
@@ -237,6 +243,11 @@ void ParameterFormula::InsertNewParameters(std::map<std::string, ParameterFormul
 void ParameterFormula::UpdateIndicesOfReferencedVariables()
 {
 	_quantityRef.UpdateIndicesOfReferencedVariables();
+}
+
+void ParameterFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	_quantityRef.UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
 }
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/PowerFormula.cpp
+++ b/src/OSPSuite.SimModel/src/PowerFormula.cpp
@@ -235,10 +235,10 @@ void PowerFormula::UpdateIndicesOfReferencedVariables()
 	m_ExponentFormula->UpdateIndicesOfReferencedVariables();
 }
 
-void PowerFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void PowerFormula::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
-	m_BaseFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
-	m_ExponentFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	m_BaseFormula->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
+	m_ExponentFormula->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
 }
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/PowerFormula.cpp
+++ b/src/OSPSuite.SimModel/src/PowerFormula.cpp
@@ -235,4 +235,10 @@ void PowerFormula::UpdateIndicesOfReferencedVariables()
 	m_ExponentFormula->UpdateIndicesOfReferencedVariables();
 }
 
+void PowerFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	m_BaseFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	m_ExponentFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+}
+
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/ProductFormula.cpp
+++ b/src/OSPSuite.SimModel/src/ProductFormula.cpp
@@ -318,4 +318,12 @@ void ProductFormula::UpdateIndicesOfReferencedVariables()
 	}
 }
 
+void ProductFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	for (int iFormula = 0; iFormula != _noOfMultipliers; iFormula++)
+	{
+		_multiplierFormulas[iFormula]->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	}
+}
+
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/ProductFormula.cpp
+++ b/src/OSPSuite.SimModel/src/ProductFormula.cpp
@@ -318,11 +318,11 @@ void ProductFormula::UpdateIndicesOfReferencedVariables()
 	}
 }
 
-void ProductFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void ProductFormula::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
 	for (int iFormula = 0; iFormula != _noOfMultipliers; iFormula++)
 	{
-		_multiplierFormulas[iFormula]->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+		_multiplierFormulas[iFormula]->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
 	}
 }
 

--- a/src/OSPSuite.SimModel/src/Quantity.cpp
+++ b/src/OSPSuite.SimModel/src/Quantity.cpp
@@ -492,12 +492,12 @@ void Quantity::UpdateIndicesOfReferencedVariables()
 	_valueFormula->UpdateIndicesOfReferencedVariables();
 }
 
-void Quantity::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void Quantity::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
 	if (_valueFormula == NULL)
 		return; //nothing to do
 
-	_valueFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	_valueFormula->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
 }
 
 

--- a/src/OSPSuite.SimModel/src/Quantity.cpp
+++ b/src/OSPSuite.SimModel/src/Quantity.cpp
@@ -492,5 +492,13 @@ void Quantity::UpdateIndicesOfReferencedVariables()
 	_valueFormula->UpdateIndicesOfReferencedVariables();
 }
 
+void Quantity::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	if (_valueFormula == NULL)
+		return; //nothing to do
+
+	_valueFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+}
+
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/QuantityReference.cpp
+++ b/src/OSPSuite.SimModel/src/QuantityReference.cpp
@@ -271,7 +271,7 @@ void QuantityReference::UpdateIndicesOfReferencedVariables()
 	_quantity->UpdateIndicesOfReferencedVariables();
 }
 
-void QuantityReference::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void QuantityReference::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
 	if (_quantity == NULL)
 		return;
@@ -279,7 +279,7 @@ void QuantityReference::UpdateScaleFactorOfReferencedVariable(const int id, cons
 	if (!_isParameter)
 		return;
 
-	_quantity->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	_quantity->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
 }
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/QuantityReference.cpp
+++ b/src/OSPSuite.SimModel/src/QuantityReference.cpp
@@ -271,4 +271,15 @@ void QuantityReference::UpdateIndicesOfReferencedVariables()
 	_quantity->UpdateIndicesOfReferencedVariables();
 }
 
+void QuantityReference::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	if (_quantity == NULL)
+		return;
+
+	if (!_isParameter)
+		return;
+
+	_quantity->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+}
+
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/SimpleProductFormula.cpp
+++ b/src/OSPSuite.SimModel/src/SimpleProductFormula.cpp
@@ -288,10 +288,10 @@ void SimpleProductFormula::UpdateIndicesOfReferencedVariables()
 		UpdateFromQuantityReference(_quantityRefs[i]);
 }
 
-void SimpleProductFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void SimpleProductFormula::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
 	for (unsigned int i = 0; i < m_ODEIndexVectorSize; i++) {
-		if (m_ODEIndexVector[i] == id) {
+		if (m_ODEIndexVector[i] == quantity_id) {
 			m_ODEScaleFactorVector[i] = ODEScaleFactor;
 		}
 	}

--- a/src/OSPSuite.SimModel/src/SimpleProductFormula.cpp
+++ b/src/OSPSuite.SimModel/src/SimpleProductFormula.cpp
@@ -11,6 +11,7 @@
 #include "SimModel/MathHelper.h"
 #include "SimModel/ProductFormula.h"
 #include "SimModel/ConstantFormula.h"
+#include "SimModel/Species.h"
 #include <assert.h>
 
 #ifdef _WINDOWS_PRODUCTION
@@ -241,7 +242,17 @@ Formula * SimpleProductFormula::RecursiveSimplify()
 
 void SimpleProductFormula::Finalize()
 {
-	//nothing to do so far
+	//If the quantity is a species, add this formula to the list of formulas that use the species.
+	//Used for updating scale factors.
+	for (unsigned int i = 0; i < _quantityRefs.size(); i++)
+	{
+		QuantityReference quantityRef = _quantityRefs[i];
+		if (quantityRef.IsSpecies())
+		{
+			SimModelNative::Species * species = quantityRef.GetSpecies();
+			species->AddFormulaReference(this);
+		}
+	}
 }
 
 void SimpleProductFormula::WriteFormulaMatlabCode (std::ostream & mrOut)
@@ -275,6 +286,15 @@ void SimpleProductFormula::UpdateIndicesOfReferencedVariables()
 {
 	for(unsigned int i=0; i<_quantityRefs.size(); i++)
 		UpdateFromQuantityReference(_quantityRefs[i]);
+}
+
+void SimpleProductFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	for (unsigned int i = 0; i < m_ODEIndexVectorSize; i++) {
+		if (m_ODEIndexVector[i] == id) {
+			m_ODEScaleFactorVector[i] = ODEScaleFactor;
+		}
+	}
 }
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/Simulation.cpp
+++ b/src/OSPSuite.SimModel/src/Simulation.cpp
@@ -619,7 +619,7 @@ OutputSchema & Simulation::GetOutputSchema()
 }
 
 void Simulation::RedimAndInitValues (int numberOfTimePoints, 
-									 double * speciesInitialValuesScaled)
+									 double * speciesInitialValuesScaled, double * speciesInitialValuesUnscaled)
 {
 	const char * ERROR_SOURCE = "Simulation::RedimValues";
 
@@ -653,7 +653,10 @@ void Simulation::RedimAndInitValues (int numberOfTimePoints,
 
 		if (species->IsConstantDuringCalculation())
 		{
-			species->FillWithInitialValue(speciesInitialValuesScaled);
+			/*
+			The method must receive the unscaled values - otherwise the sub-sequential "GetInitialValue" might return the scaled value of a formula.
+			*/
+			species->FillWithInitialValue(speciesInitialValuesUnscaled);
 
 			//for constant species, fill with initial sensitivity value for all parameters
 			numberOfSensitivityTimePoints = 1;

--- a/src/OSPSuite.SimModel/src/Species.cpp
+++ b/src/OSPSuite.SimModel/src/Species.cpp
@@ -41,7 +41,7 @@ Species::Species(void)
 Species::~Species(void)
 {
 	_rhsFormulaList.FreeVector();
-	_allFormulaList.FreeVector();
+	_allFormulaVector.~vector();
 	if (_RHS_UsedVariablesIndices != NULL)
 	{
 		delete[] _RHS_UsedVariablesIndices;
@@ -68,7 +68,7 @@ void Species::SetODEScaleFactor (double p_ODEScaleFactor)
 	{
 		for (int i = 0; i < _allFormulaListSize; i++)
 		{
-			Formula * rhsFormula = _allFormulaList[i];
+			Formula * rhsFormula = _allFormulaVector[i];
 			rhsFormula->UpdateScaleFactorOfReferencedVariable(GetODEIndex(), m_ODEScaleFactor);
 		}
 	}
@@ -514,8 +514,8 @@ void Species::GetRHSUsedBandRange(int & upperHalfBandWidth, int & lowerHalfBandW
 
 void Species::AddFormulaReference(Formula * formula)
 {
-	_allFormulaList.Add(formula);
-	_allFormulaListSize = _allFormulaList.size();
+	_allFormulaVector.push_back(formula);
+	_allFormulaListSize = _allFormulaVector.size();
 }
 
 bool Species::NegativeValuesAllowed(void)

--- a/src/OSPSuite.SimModel/src/SumFormula.cpp
+++ b/src/OSPSuite.SimModel/src/SumFormula.cpp
@@ -264,11 +264,11 @@ void SumFormula::UpdateIndicesOfReferencedVariables()
 	}
 }
 
-void SumFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void SumFormula::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
 	for (int iFormula = 0; iFormula != _noOfSummands; iFormula++)
 	{
-		_summandFormulas[iFormula]->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+		_summandFormulas[iFormula]->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
 	}
 }
 

--- a/src/OSPSuite.SimModel/src/SumFormula.cpp
+++ b/src/OSPSuite.SimModel/src/SumFormula.cpp
@@ -264,4 +264,12 @@ void SumFormula::UpdateIndicesOfReferencedVariables()
 	}
 }
 
+void SumFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	for (int iFormula = 0; iFormula != _noOfSummands; iFormula++)
+	{
+		_summandFormulas[iFormula]->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	}
+}
+
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/TableFormula.cpp
+++ b/src/OSPSuite.SimModel/src/TableFormula.cpp
@@ -438,6 +438,11 @@ void TableFormula::UpdateIndicesOfReferencedVariables()
 	//nothing to do so far
 }
 
+void TableFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	//nothing to do so far
+}
+
 void TableFormula::SetUseDerivedValues(bool useDerivedValues)
 {
 	_useDerivedValues = useDerivedValues;

--- a/src/OSPSuite.SimModel/src/TableFormula.cpp
+++ b/src/OSPSuite.SimModel/src/TableFormula.cpp
@@ -438,7 +438,7 @@ void TableFormula::UpdateIndicesOfReferencedVariables()
 	//nothing to do so far
 }
 
-void TableFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void TableFormula::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
 	//nothing to do so far
 }

--- a/src/OSPSuite.SimModel/src/TableFormulaWithOffset.cpp
+++ b/src/OSPSuite.SimModel/src/TableFormulaWithOffset.cpp
@@ -221,10 +221,10 @@ void TableFormulaWithOffset::UpdateIndicesOfReferencedVariables()
 	_offsetObject->UpdateIndicesOfReferencedVariables();
 }
 
-void TableFormulaWithOffset::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void TableFormulaWithOffset::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
-	_tableObject->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
-	_offsetObject->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	_tableObject->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
+	_offsetObject->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
 }
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/TableFormulaWithOffset.cpp
+++ b/src/OSPSuite.SimModel/src/TableFormulaWithOffset.cpp
@@ -221,4 +221,10 @@ void TableFormulaWithOffset::UpdateIndicesOfReferencedVariables()
 	_offsetObject->UpdateIndicesOfReferencedVariables();
 }
 
+void TableFormulaWithOffset::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	_tableObject->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	_offsetObject->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+}
+
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/TableFormulaWithXArgument.cpp
+++ b/src/OSPSuite.SimModel/src/TableFormulaWithXArgument.cpp
@@ -265,10 +265,10 @@ void TableFormulaWithXArgument::UpdateIndicesOfReferencedVariables()
 	_XArgumentObject->UpdateIndicesOfReferencedVariables();
 }
 
-void TableFormulaWithXArgument::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void TableFormulaWithXArgument::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
-	_tableObject->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
-	_XArgumentObject->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	_tableObject->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
+	_XArgumentObject->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
 }
 
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/TableFormulaWithXArgument.cpp
+++ b/src/OSPSuite.SimModel/src/TableFormulaWithXArgument.cpp
@@ -265,4 +265,10 @@ void TableFormulaWithXArgument::UpdateIndicesOfReferencedVariables()
 	_XArgumentObject->UpdateIndicesOfReferencedVariables();
 }
 
+void TableFormulaWithXArgument::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	_tableObject->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	_XArgumentObject->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+}
+
 }//.. end "namespace SimModelNative"

--- a/src/OSPSuite.SimModel/src/UnaryFunctionFormula.cpp
+++ b/src/OSPSuite.SimModel/src/UnaryFunctionFormula.cpp
@@ -174,9 +174,9 @@ void UnaryFunctionFormula::UpdateIndicesOfReferencedVariables()
 	m_ArgumentFormula->UpdateIndicesOfReferencedVariables();
 }
 
-void UnaryFunctionFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void UnaryFunctionFormula::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
-	m_ArgumentFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+	m_ArgumentFormula->UpdateScaleFactorOfReferencedVariable(quantity_id, ODEScaleFactor);
 }
 
 

--- a/src/OSPSuite.SimModel/src/UnaryFunctionFormula.cpp
+++ b/src/OSPSuite.SimModel/src/UnaryFunctionFormula.cpp
@@ -174,6 +174,11 @@ void UnaryFunctionFormula::UpdateIndicesOfReferencedVariables()
 	m_ArgumentFormula->UpdateIndicesOfReferencedVariables();
 }
 
+void UnaryFunctionFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	m_ArgumentFormula->UpdateScaleFactorOfReferencedVariable(id, ODEScaleFactor);
+}
+
 
 //-------------------------------------------------------------------
 //---- arccos

--- a/src/OSPSuite.SimModel/src/VariableFormula.cpp
+++ b/src/OSPSuite.SimModel/src/VariableFormula.cpp
@@ -154,9 +154,9 @@ void VariableFormula::UpdateIndicesOfReferencedVariables()
 	m_ODEVariableIndex = _quantityRef.GetODEIndex();
 }
 
-void VariableFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+void VariableFormula::UpdateScaleFactorOfReferencedVariable(const int quantity_id, const double ODEScaleFactor)
 {
-	if (m_ODEVariableIndex == id)
+	if (m_ODEVariableIndex == quantity_id)
 		m_ODEVariableScaleFactor = ODEScaleFactor;
 }
 

--- a/src/OSPSuite.SimModel/src/VariableFormula.cpp
+++ b/src/OSPSuite.SimModel/src/VariableFormula.cpp
@@ -4,6 +4,7 @@
 
 #include "SimModel/VariableFormula.h"
 #include "SimModel/ConstantFormula.h"
+#include "SimModel/Species.h"
 #include <assert.h>
 
 #ifdef _WINDOWS_PRODUCTION
@@ -55,6 +56,13 @@ void VariableFormula::SetQuantityReference (const QuantityReference & quantityRe
 
 void VariableFormula::Finalize()
 {
+	//If the quantity is a species, add this formula to the list of formulas that use the species.
+	//Used for updating scale factors.
+	if (_quantityRef.IsSpecies())
+	{
+		SimModelNative::Species * species = _quantityRef.GetSpecies();
+		species->AddFormulaReference(this);
+	}
 }
 
 double VariableFormula::DE_Compute (const double * y, const double time, ScaleFactorUsageMode scaleFactorMode)
@@ -144,6 +152,12 @@ void VariableFormula::AppendUsedParameters(std::set<int> & usedParameterIDs)
 void VariableFormula::UpdateIndicesOfReferencedVariables()
 {
 	m_ODEVariableIndex = _quantityRef.GetODEIndex();
+}
+
+void VariableFormula::UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor)
+{
+	if (m_ODEVariableIndex == id)
+		m_ODEVariableScaleFactor = ODEScaleFactor;
 }
 
 }//.. end "namespace SimModelNative"

--- a/tests/OSPSuite.SimModel.Tests/src/SimulationSpecs.cpp
+++ b/tests/OSPSuite.SimModel.Tests/src/SimulationSpecs.cpp
@@ -2355,7 +2355,7 @@ namespace SimulationTests
 
     public:
         [TestAttribute]
-		[Ignore("This test should be investigated and completed after the bugfix")]
+//		[Ignore("This test should be investigated and completed after the bugfix")]
         void should_update_species_initial_values_in_the_simulation_xml_node()
         {
 			//initial system is:
@@ -2421,8 +2421,8 @@ namespace SimulationTests
 				BDDExtensions::ShouldBeEqualTo(y2_startvalue, 4.0);
 
 				//check new scale factor //TODO enable test as soon as saving scale factor bug is fixed
-				//BDDExtensions::ShouldBeEqualTo(y1->GetODEScaleFactor(), 5.0);
-				//BDDExtensions::ShouldBeEqualTo(y2->GetODEScaleFactor(), 6.0);
+				BDDExtensions::ShouldBeEqualTo(y1->GetODEScaleFactor(), 5.0);
+				BDDExtensions::ShouldBeEqualTo(y2->GetODEScaleFactor(), 6.0);
 			}
 			catch(ErrorData & ED)
 			{


### PR DESCRIPTION
- Fixes the problem that new scale factors are not propagated to the species instances within the formulas, resulting in incorrect scaling.

- The species object has a list of all formulas that use the respective species (_allFormulaList). This list is filled upon calling Finalize() on the formula.
- Each time Species.SetODEScaleFactor() is called, all formulas referencing the species are called to update their scale factors via UpdateScaleFactorOfReferencedVariable(const int id, const double ODEScaleFactor). This is done recursively, analogously to DE_Compute().
- Species::FillWithInitialValue(const double * speciesInitialValuesUnscaled) receives unscaled values. Otherwise, Species::GetInitialValue (const double * y, double time) might return a scaled value of a formula, as opposed to specification.

-This commit requires an adaptation of the tests! ExplicitFormulaExtender must have valid id, otherwise some tests fail when calling Species::AddFormulaReference(Formula * formula)