### PR TITLE
Fixes #121 Simulation warnings are not cleared in case of "Autoreduce tolerances"

### DIFF
--- a/src/OSPSuite.SimModel/Simulation.cs
+++ b/src/OSPSuite.SimModel/Simulation.cs
@@ -175,8 +175,8 @@ namespace OSPSuite.SimModel
       public static extern int GetNumberOfSolverWarnings(IntPtr simulation);
 
       [DllImport(SimModelImportDefinitions.NATIVE_DLL, CallingConvention = SimModelImportDefinitions.CALLING_CONVENTION)]
-      public static extern void FillSolverWarnings(IntPtr simulation, [In, Out] double[] outputTimes, [In, Out] string[] warnings, 
-         int size, out bool success, out string errorMessage);
+      public static extern void FillSolverWarnings(IntPtr simulation, int size, [In, Out] double[] outputTimes, 
+         [In, Out] string[] warnings, out bool success, out string errorMessage);
 
       [DllImport(SimModelImportDefinitions.NATIVE_DLL, CallingConvention = SimModelImportDefinitions.CALLING_CONVENTION)]
       public static extern IntPtr GetQuantityByPath(IntPtr simulation, string quantityPathWithoutRoot, out bool success, out string errorMessage);
@@ -339,7 +339,7 @@ namespace OSPSuite.SimModel
          var times = new double[numberOfWarnings];
          var warnings=new string[numberOfWarnings];
 
-         SimulationImports.FillSolverWarnings(_simulation, times, warnings, numberOfWarnings, out var success, out var errorMessage);
+         SimulationImports.FillSolverWarnings(_simulation, numberOfWarnings, times, warnings, out var success, out var errorMessage);
          evaluateCppCallResult(success, errorMessage);
 
          for (var i = 0; i < numberOfWarnings; i++)

--- a/src/OSPSuite.SimModelNative/include/SimModel/SimulationTask.h
+++ b/src/OSPSuite.SimModelNative/include/SimModel/SimulationTask.h
@@ -14,7 +14,7 @@ namespace SimModelNative
 class SimulationTask
 {
 private:
-	static std::string GetErrorMessageForNegativeVaribales(const std::vector<std::string> & positiveVariablesWithNegativeValues);
+	static std::string GetErrorMessageForNegativeVariables(const std::vector<std::string> & positiveVariablesWithNegativeValues, double solverOutputTime);
 protected:
 	static std::vector <OutputTimePoint> OutputTimePoints(DoubleQueue userOutputTimePoints, 
 	                                                      DoubleQueue switchTimePoints,
@@ -28,7 +28,7 @@ public:
 
 	static void SetValuesBelowAbsTolLevelToZero(double * values, int valuesSize, double absTol);
 
-	static void CheckForNegativeValues(Species ** odeVariables, int numberOfVariables, double absTol);
+	static void CheckForNegativeValues(Species ** odeVariables, int numberOfVariables, double absTol, double solverOutputTime);
 
 	//mark all parameters which are used in any ODE varaible or observer as unused
 	static void MarkUsedParameters(Simulation * sim);

--- a/src/OSPSuite.SimModelNative/src/DESolver.cpp
+++ b/src/OSPSuite.SimModelNative/src/DESolver.cpp
@@ -322,7 +322,7 @@ namespace SimModelNative
 					//check for not allowed negative values
 					//(must be done BEFORE rescaling the values back)
 					if (_parentSim->Options().CheckForNegativeValues())
-						SimulationTask::CheckForNegativeValues(m_ODEVariables, m_ODE_NumUnknowns, m_SolverProperties.GetAbsTol());
+						SimulationTask::CheckForNegativeValues(m_ODEVariables, m_ODE_NumUnknowns, m_SolverProperties.GetAbsTol(), solverOutputTime);
 
 					//save sensitivity values at the current time step for all variables
 					storeSensitivityValues(TimeStepNumber, sensitivityValues);

--- a/src/OSPSuite.SimModelNative/src/Simulation.cpp
+++ b/src/OSPSuite.SimModelNative/src/Simulation.cpp
@@ -1046,6 +1046,9 @@ void Simulation::RunSimulation (bool & toleranceWasReduced, double & newAbsTol, 
 
 					//reset simulation state (parameter values changed by switches etc.)
 					ResetState();
+
+               //reset solver warnings
+               _solverWarnings.clear();
 				}
 				else
 					throw;

--- a/src/OSPSuite.SimModelNative/src/SimulationTask.cpp
+++ b/src/OSPSuite.SimModelNative/src/SimulationTask.cpp
@@ -6,6 +6,7 @@
 #include "SimModel/SwitchTask.h"
 #include "SimModel/TableFormula.h"
 #include "SimModel/TableFormulaWithOffset.h"
+#include "XMLWrapper/XMLHelper.h"
 #include <set>
 #include <map>
 
@@ -191,7 +192,7 @@ void SimulationTask::SetValuesBelowAbsTolLevelToZero(double * values, int values
 	}
 }
 
-void SimulationTask::CheckForNegativeValues(Species ** odeVariables, int numberOfVariables, double absTol)
+void SimulationTask::CheckForNegativeValues(Species ** odeVariables, int numberOfVariables, double absTol, double solverOutputTime)
 {
 	const char * ERROR_SOURCE = "SimulationTask::CheckForNegativeValues";
 	vector<string> positiveVariablesWithNegativeValues;
@@ -208,13 +209,12 @@ void SimulationTask::CheckForNegativeValues(Species ** odeVariables, int numberO
 			//found not allowed negative value. 
 			//Cache variable name for the error message and continue with the next variable
 			positiveVariablesWithNegativeValues.push_back(odeVariable->GetFullName());
-			break;
 		}
 		
 	}
 
-	if (positiveVariablesWithNegativeValues.size()>0)
-		throw ErrorData(ErrorData::ED_ERROR, ERROR_SOURCE, GetErrorMessageForNegativeVaribales(positiveVariablesWithNegativeValues));
+	if (!positiveVariablesWithNegativeValues.empty())
+		throw ErrorData(ErrorData::ED_ERROR, ERROR_SOURCE, GetErrorMessageForNegativeVariables(positiveVariablesWithNegativeValues, solverOutputTime));
 
 }
 
@@ -266,11 +266,11 @@ void SimulationTask::MarkUsedParameters(Simulation * sim)
 	}
 }
 
-string SimulationTask::GetErrorMessageForNegativeVaribales(const vector<string> & positiveVariablesWithNegativeValues)
+string SimulationTask::GetErrorMessageForNegativeVariables(const vector<string> & positiveVariablesWithNegativeValues, double solverOutputTime)
 {
 	string msg;
 
-	msg += "Simulation run failed: some variables became negative. There are different possible reasons for this:";
+	msg += "Simulation run failed: some variables became negative when trying to reach t="+ XMLHelper::ToString(solverOutputTime)+". There are different possible reasons for this:";
 	msg += "\n\n";
 	msg += "  - Solver tolerances are too high. Please reduce the absolute and relative tolerances by one order of magnitude (e.g. from 1E-9 to 1E-10) and restart the simulation.";
 	msg += "\n";

--- a/tests/OSPSuite.SimModel.Tests/SimulationSpecs.cs
+++ b/tests/OSPSuite.SimModel.Tests/SimulationSpecs.cs
@@ -920,6 +920,7 @@ namespace OSPSuite.SimModel.Tests
          catch (Exception ex)
          {
             ex.Message.Contains("negative").ShouldBeTrue();
+            ex.Message.Contains("when trying to reach t=").ShouldBeTrue();
 
             //expected behavior. Leave the test case
             return;
@@ -1343,4 +1344,26 @@ namespace OSPSuite.SimModel.Tests
          }
       }
    }
+
+   public class when_retrieving_solver_warnings : concern_for_Simulation
+   {
+      protected override void Because()
+      {
+         base.Because();
+         LoadFinalizeAndRunSimulation("TestWarnings_LowMxStep");
+      }
+
+      protected override void OptionalTasksBeforeRun()
+      {
+         sut.Options.StopOnWarnings = false;
+      }
+
+      [Observation]
+      public void should_retrieve_solver_warnings()
+      {
+         var warnings = sut.SolverWarnings;
+         warnings.Count().ShouldBeGreaterThan(0);
+      }
+   }
+
 }

--- a/tests/TestAppCpp/src/TestAppCpp.cpp
+++ b/tests/TestAppCpp/src/TestAppCpp.cpp
@@ -6,16 +6,17 @@ int main()
 
    try
    {
-      CoInitialize(NULL);
+      CoInitialize(NULL); 
 
       //TestLeaks();
-      TestSetTablePoints();
+      //TestSetTablePoints();
 
       string simName;
-      simName = "SimModel4_ExampleInput06_Modified";
+      simName = "Test_dynamic_reduced_3"; 
+//      simName = "SimModel4_ExampleInput06_Modified";
       //simName = "SolverError01";
 
-      //Test1(simName);
+      Test1(simName);
    }
    catch (ErrorData& ED)
    {
@@ -35,8 +36,8 @@ int main()
    }
 
    ClearDynamicLibrary();
-//   cout << "Enter anything";
-//   _getch();
+   cout << "Enter anything";
+   _getch();
 
    return 0;
 }

--- a/tests/TestData/TestWarnings_LowMxStep.xml
+++ b/tests/TestData/TestWarnings_LowMxStep.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Simulation objectPathDelimiter="|" version="4" xmlns="http://www.systems-biology.com">
+  <FormulaList>
+    <ExplicitFormula id="5">
+      <Equation>A0</Equation>
+      <ReferenceList>
+        <R alias="A0" id="2" />
+      </ReferenceList>
+    </ExplicitFormula>
+    <ExplicitFormula id="8">
+      <Equation>-(k * C1)</Equation>
+      <ReferenceList>
+        <R alias="k" id="3" />
+        <R alias="C1" id="4" />
+      </ReferenceList>
+    </ExplicitFormula>
+  </FormulaList>
+  <VariableList>
+    <V id="4" entityId="C1" name="C1" path="S3|Organism|C1" unit="µmol" persistable="1" initialValueFormulaId="5" negativeValuesAllowed="0">
+      <ScaleFactor>1</ScaleFactor>
+      <RHSFormulaList>
+        <RHSFormula id="8" />
+      </RHSFormulaList>
+    </V>
+  </VariableList>
+  <ParameterList>
+    <P id="2" entityId="A0" name="A0" path="S3|Organism|A0" persistable="0" value="10" />
+    <P id="3" entityId="k" name="k" path="S3|Organism|k" persistable="0" value="0.5" />
+    <P id="10" entityId="AbsTol" name="AbsTol" path="AbsTol" persistable="0" value="1E-10" />
+    <P id="12" entityId="RelTol" name="RelTol" path="RelTol" persistable="0" value="0.000001" />
+    <P id="14" entityId="H0" name="H0" path="H0" persistable="0" value="1E-10" />
+    <P id="16" entityId="HMin" name="HMin" path="HMin" persistable="0" value="0" />
+    <P id="18" entityId="HMax" name="HMax" path="HMax" persistable="0" value="60" />
+    <P id="20" entityId="MxStep" name="MxStep" path="MxStep" persistable="0" value="2" />
+    <P id="22" entityId="UseJacobian" name="UseJacobian" path="UseJacobian" persistable="0" value="1" />
+  </ParameterList>
+  <Solver name="CVODE1002_2">
+    <H0 id="14" />
+    <HMax id="18" />
+    <HMin id="16" />
+    <AbsTol id="10" />
+    <MxStep id="20" />
+    <RelTol id="12" />
+    <UseJacobian id="22" />
+  </Solver>
+  <OutputSchema>
+    <OutputIntervalList>
+      <OutputInterval distribution="Uniform">
+        <StartTime>0</StartTime>
+        <EndTime>4</EndTime>
+        <NumberOfTimePoints>21</NumberOfTimePoints>
+      </OutputInterval>
+    </OutputIntervalList>
+  </OutputSchema>
+</Simulation>

--- a/tests/TestData/Test_dynamic_reduced_3.xml
+++ b/tests/TestData/Test_dynamic_reduced_3.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Simulation objectPathDelimiter="|" version="4" xmlns="http://www.systems-biology.com">
+  <FormulaList>
+    <ExplicitFormula id="4">
+      <Equation>V&gt;0 ? M/V : 0</Equation>
+      <ReferenceList>
+        <R alias="M" id="2" />
+        <R alias="V" id="1" />
+      </ReferenceList>
+    </ExplicitFormula>
+    <ExplicitFormula id="5">
+      <Equation>1</Equation>
+      <ReferenceList>
+        <R alias="C1" id="2" />
+      </ReferenceList>
+    </ExplicitFormula>
+    <ExplicitFormula id="8">
+      <Equation>exp(Ctotal*MW)</Equation>
+      <ReferenceList>
+        <R alias="Ctotal" id="3" />
+        <R alias="MW" id="7" />
+      </ReferenceList>
+    </ExplicitFormula>
+    <ExplicitFormula id="9">
+      <Equation>1E-09</Equation>
+    </ExplicitFormula>
+    <ExplicitFormula id="11">
+      <Equation>0.0001</Equation>
+    </ExplicitFormula>
+    <ExplicitFormula id="13">
+      <Equation>1E-10</Equation>
+    </ExplicitFormula>
+    <ExplicitFormula id="15">
+      <Equation>0</Equation>
+    </ExplicitFormula>
+    <ExplicitFormula id="17">
+      <Equation>60</Equation>
+    </ExplicitFormula>
+    <ExplicitFormula id="19">
+      <Equation>100000</Equation>
+    </ExplicitFormula>
+    <ExplicitFormula id="21">
+      <Equation>1</Equation>
+    </ExplicitFormula>
+  </FormulaList>
+  <VariableList>
+    <V id="2" entityId="eyNPwyaV0ESkvamILmMtMg" name="C1" path="S1|Organism|C1" unit="µmol" persistable="0" value="0" negativeValuesAllowed="0">
+      <ScaleFactor>1</ScaleFactor>
+      <RHSFormulaList>
+        <RHSFormula id="5" />
+      </RHSFormulaList>
+    </V>
+  </VariableList>
+  <ParameterList>
+    <P id="1" entityId="Mq1LfV3k_kK8syucaRhE3g" name="Volume" path="S1|Organism|Volume" unit="l" persistable="0" value="1" />
+    <P id="3" entityId="euylUVOMbUW7_IHfwRq5gQ" name="Concentration" path="S1|Organism|C1|Concentration" unit="µmol/l" persistable="1" formulaId="4" />
+    <P id="6" entityId="TjhJh2WL6UCdRPocOMzV1Q" name="dynamic" path="S1|C1|dynamic" unit="kg/l" persistable="1" formulaId="8" />
+    <P id="7" entityId="xYMPRUSc2Ea4ZALSZ8eOzQ" name="Molecular weight" path="S1|C1|Molecular weight" unit="kg/µmol" persistable="0" value="2E-09" />
+    <P id="10" entityId="AbsTol" name="AbsTol" path="AbsTol" persistable="0" formulaId="9" />
+    <P id="12" entityId="RelTol" name="RelTol" path="RelTol" persistable="0" formulaId="11" />
+    <P id="14" entityId="H0" name="H0" path="H0" persistable="0" formulaId="13" />
+    <P id="16" entityId="HMin" name="HMin" path="HMin" persistable="0" formulaId="15" />
+    <P id="18" entityId="HMax" name="HMax" path="HMax" persistable="0" formulaId="17" />
+    <P id="20" entityId="MxStep" name="MxStep" path="MxStep" persistable="0" formulaId="19" />
+    <P id="22" entityId="UseJacobian" name="UseJacobian" path="UseJacobian" persistable="0" formulaId="21" />
+  </ParameterList>
+  <Solver name="CVODES">
+    <H0 id="14" />
+    <HMax id="18" />
+    <HMin id="16" />
+    <AbsTol id="10" />
+    <MxStep id="20" />
+    <RelTol id="12" />
+    <UseJacobian id="22" />
+  </Solver>
+  <OutputSchema>
+    <OutputIntervalList>
+      <OutputInterval distribution="Uniform">
+        <StartTime>0</StartTime>
+        <EndTime>1440</EndTime>
+        <NumberOfTimePoints>97</NumberOfTimePoints>
+      </OutputInterval>
+    </OutputIntervalList>
+  </OutputSchema>
+</Simulation>


### PR DESCRIPTION
Fixes #120 Wrong Pinvoke signature (results in crash in case of solver warnings)
Fixes #119 List correct output that first crosses the "zero line" for negativeValuesAllowed="0"
Fixes #118 Return the timepoint in the error message for negativeValuesAllowed="0"