### PR TITLE
Migrate legacy C++/CLI unit tests to native Google Test format

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: 'true'
 
@@ -70,6 +70,8 @@ jobs:
       - name: Install Mono (NuGet CLI runtime)
         run: |
           if [ "${{ runner.os }}" = "macOS" ]; then
+            brew trust aws/tap
+            brew trust azure/bicep
             brew install mono
           else
             sudo apt-get update
@@ -77,7 +79,7 @@ jobs:
           fi
 
       - name: Setup NuGet CLI
-        uses: NuGet/setup-nuget@v2
+        uses: NuGet/setup-nuget@v4
 
       # buildNix.sh uses BOTH the standalone `nuget` CLI (for the C++ build's
       # packages.config — pulls upstream natives/headers from FuncParser and
@@ -111,7 +113,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: 'true'
 

--- a/tests/OSPSuite.SimModelNative.Tests/OSPSuite.SimModelNative.Tests.vcxproj
+++ b/tests/OSPSuite.SimModelNative.Tests/OSPSuite.SimModelNative.Tests.vcxproj
@@ -113,6 +113,7 @@
   </ItemDefinitionGroup>
   <!-- Test source files -->
   <ItemGroup>
+    <ClCompile Include="src\TestEnvironment.cpp" />
     <ClCompile Include="src\ErrorDataSpecs.cpp" />
     <ClCompile Include="src\SimulationOptionsSpecs.cpp" />
     <ClCompile Include="src\MathHelperSpecs.cpp" />
@@ -120,6 +121,12 @@
     <ClCompile Include="src\ConstantFormulaSpecs.cpp" />
     <ClCompile Include="src\OutputSchemaSpecs.cpp" />
     <ClCompile Include="src\RcmSpecs.cpp" />
+    <ClCompile Include="src\ExplicitFormulaSpecs.cpp" />
+    <ClCompile Include="src\ParameterSpecs.cpp" />
+    <ClCompile Include="src\SimulationTaskSpecs.cpp" />
+    <ClCompile Include="src\TableFormulaSpecs.cpp" />
+    <ClCompile Include="src\TableFormulaWithOffsetSpecs.cpp" />
+    <ClCompile Include="src\TableFormulaWithXArgumentSpecs.cpp" />
   </ItemGroup>
   <!-- SimModelNative sources compiled directly into the test executable -->
   <ItemGroup>

--- a/tests/OSPSuite.SimModelNative.Tests/OSPSuite.SimModelNative.Tests.vcxproj
+++ b/tests/OSPSuite.SimModelNative.Tests/OSPSuite.SimModelNative.Tests.vcxproj
@@ -128,6 +128,9 @@
     <ClCompile Include="src\TableFormulaWithOffsetSpecs.cpp" />
     <ClCompile Include="src\TableFormulaWithXArgumentSpecs.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="src\TableFormulaTestExtender.h" />
+  </ItemGroup>
   <!-- SimModelNative sources compiled directly into the test executable -->
   <ItemGroup>
     <ClCompile Include="..\..\src\OSPSuite.SimModelNative\Src\BandwidthReduction.cpp" />

--- a/tests/OSPSuite.SimModelNative.Tests/OSPSuite.SimModelNative.Tests.vcxproj.filters
+++ b/tests/OSPSuite.SimModelNative.Tests/OSPSuite.SimModelNative.Tests.vcxproj.filters
@@ -187,6 +187,27 @@
     <ClCompile Include="src\RcmSpecs.cpp">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="src\ExplicitFormulaSpecs.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="src\TestEnvironment.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="src\ParameterSpecs.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="src\SimulationTaskSpecs.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="src\TableFormulaSpecs.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="src\TableFormulaWithOffsetSpecs.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="src\TableFormulaWithXArgumentSpecs.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
     <ClCompile Include="src\SimulationOptionsSpecs.cpp">
       <Filter>src</Filter>
     </ClCompile>

--- a/tests/OSPSuite.SimModelNative.Tests/src/ExplicitFormulaSpecs.cpp
+++ b/tests/OSPSuite.SimModelNative.Tests/src/ExplicitFormulaSpecs.cpp
@@ -1,0 +1,326 @@
+#include <gtest/gtest.h>
+#include "SimModel/ExplicitFormula.h"
+#include "SimModel/QuantityReference.h"
+#include "SimModel/Quantity.h"
+#include "SimModel/Parameter.h"
+#include "SimModel/Species.h"
+#include "SimModel/Formula.h"
+#include "SimModel/GlobalConstants.h"
+#include "SimModel/SimModelTypeDefs.h"
+#include "SimModel/TObjectVector.h"
+#include <ErrorData.h>
+#include <cmath>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace SimModelNative;
+
+namespace
+{
+   // Render a numeric value as an equation string (replaces the C++/CLI helper's
+   // dependency on XMLHelper::ToString).
+   std::string FormatNumber(double value)
+   {
+      std::ostringstream os;
+      os << std::setprecision(16) << value;
+      return os.str();
+   }
+}
+
+// --- Helper extenders (originally in ExplicitFormulaSpecsHelper.{h,cpp}) -------
+// They provide access to protected members of the production classes via public
+// inheritance so the explicit-formula behaviour can be exercised directly.
+
+class ParameterExtender : public Parameter
+{
+public:
+   void SetName(const std::string& name) { _name = name; }
+};
+
+class SpeciesExtender : public Species
+{
+public:
+   void SetName(const std::string& name) { _name = name; }
+};
+
+class QuantityReferenceExtender : public QuantityReference
+{
+public:
+   void SetQuantity(Quantity* quantity)
+   {
+      _quantity = quantity;
+
+      if (dynamic_cast<Species*>(_quantity) != nullptr)
+         _isSpecies = true;
+      else if (dynamic_cast<Parameter*>(_quantity) != nullptr)
+         _isParameter = true;
+   }
+
+   void SetIsTime(bool isTime) { _isTime = isTime; }
+};
+
+class ExplicitFormulaExtender : public ExplicitFormula
+{
+public:
+   void SetEquation(const std::string& equation) { _equation = equation; }
+
+   TObjectVector<QuantityReference>& QuantityRefs() { return _quantityRefs; }
+
+   ParameterExtender* AddParameterReference(const std::string& name, const std::string& equation, bool isFixed = false)
+   {
+      return AddParameterReference(name, FormulaFrom(equation), isFixed);
+   }
+
+   ParameterExtender* AddParameterReference(const std::string& name, ExplicitFormula* formula, bool isFixed = false)
+   {
+      ParameterExtender* param = new ParameterExtender();
+      param->SetName(name);
+      param->SetFormula(formula);
+
+      AddQuantityReference(param, isFixed);
+
+      return param;
+   }
+
+   SpeciesExtender* AddSpeciesReference(const std::string& name, const std::string& initialValueEquation, bool isFixed = false)
+   {
+      return AddSpeciesReference(name, FormulaFrom(initialValueEquation), isFixed);
+   }
+
+   SpeciesExtender* AddSpeciesReference(const std::string& name, ExplicitFormula* initialValueFormula, bool isFixed = false)
+   {
+      SpeciesExtender* species = new SpeciesExtender();
+      species->SetName(name);
+      species->SetFormula(initialValueFormula);
+
+      AddQuantityReference(species, isFixed);
+
+      return species;
+   }
+
+   void AddSpeciesReference(SpeciesExtender* species)
+   {
+      AddQuantityReference(species, species->IsFixed());
+   }
+
+   void AddTimeReference()
+   {
+      QuantityReferenceExtender* quantityRef = new QuantityReferenceExtender();
+      quantityRef->SetIsTime(true);
+      quantityRef->SetAlias(csTime);
+
+      _quantityRefs.push_back(quantityRef);
+   }
+
+   void AddQuantityReference(Quantity* quantity, bool isFixed = false)
+   {
+      quantity->SetIsFixed(isFixed);
+
+      QuantityReferenceExtender* quantityRef = new QuantityReferenceExtender();
+      quantityRef->SetQuantity(quantity);
+      quantityRef->SetAlias(quantity->GetName());
+
+      _quantityRefs.push_back(quantityRef);
+   }
+
+   bool Simplify(bool forCurrentRunOnly)
+   {
+      if (_formula == nullptr)
+         ExplicitFormula::SetupFormula();
+
+      return ExplicitFormula::Simplify(forCurrentRunOnly);
+   }
+
+protected:
+   ExplicitFormulaExtender* FormulaFrom(const std::string& equation)
+   {
+      ExplicitFormulaExtender* formula = new ExplicitFormulaExtender();
+      formula->SetEquation(equation);
+      formula->Finalize();
+
+      return formula;
+   }
+};
+
+// --- Tests --------------------------------------------------------------------
+
+TEST(when_creating_for_references_independent_equation, should_calculate_correct_value)
+{
+   const double pi = 2 * std::asin(1.0);
+
+   ExplicitFormulaExtender formula;
+   formula.SetEquation("sin(pi/2)*sqrt(4.0)");
+   formula.Finalize();
+
+   double value = formula.DE_Compute(nullptr, 0.0, USE_SCALEFACTOR);
+
+   EXPECT_NEAR(std::sin(pi / 2) * std::sqrt(4.0), value, 1e-10);
+}
+
+class when_creating_for_parameter_and_species_references : public ::testing::Test
+{
+protected:
+   double _p1 = 0, _p2 = 0, _x = 0, _y = 0, _value = 0;
+   ExplicitFormulaExtender _formula;
+
+   void SetUp() override
+   {
+      _formula.SetEquation("p1*x+p2*y");
+
+      _p1 = 2; _p2 = 3; _x = 4; _y = 5;
+      _value = _p1 * _x + _p2 * _y;
+
+      _formula.AddParameterReference("p1", FormatNumber(_p1));
+      _formula.AddParameterReference("p2", FormatNumber(_p2));
+
+      SpeciesExtender* X = _formula.AddSpeciesReference("x", "-1"); // x value doesn't matter
+      SpeciesExtender* Y = _formula.AddSpeciesReference("y", "-1"); // y value doesn't matter
+
+      X->SetIsChangedBySwitch(true); // force using as variable, not as parameter
+      Y->SetIsChangedBySwitch(true);
+
+      X->SetODEIndex(0);
+      Y->SetODEIndex(1);
+   }
+};
+
+TEST_F(when_creating_for_parameter_and_species_references, should_calculate_correct_value_without_simplifying)
+{
+   _formula.Finalize();
+
+   double yy[2] = {_x, _y};
+   double value = _formula.DE_Compute(yy, 0.0, USE_SCALEFACTOR);
+
+   EXPECT_DOUBLE_EQ(_value, value);
+}
+
+TEST_F(when_creating_for_parameter_and_species_references, should_calculate_correct_value_with_simplifying)
+{
+   EXPECT_FALSE(_formula.Simplify(false));
+
+   _formula.Finalize();
+
+   double yy[2] = {_x, _y};
+   double value = _formula.DE_Compute(yy, 0.0, USE_SCALEFACTOR);
+
+   EXPECT_DOUBLE_EQ(_value, value);
+}
+
+class when_creating_for_parameter_species_and_time : public ::testing::Test
+{
+protected:
+   double _p2 = 0, _x = 0, _y = 0;
+   ExplicitFormulaExtender _formula;
+   ExplicitFormulaExtender* _p1Formula = nullptr;
+
+   // p1 = Time + x
+   // p2 = const
+   // f(p1, p2, x, y) = p1*x + p2*y
+   void SetUp() override
+   {
+      _formula.SetEquation("p1*x+p2*y");
+
+      _p2 = 3; _x = 4; _y = 5;
+
+      SpeciesExtender* X = _formula.AddSpeciesReference("x", "-1");
+      SpeciesExtender* Y = _formula.AddSpeciesReference("y", "-1");
+
+      X->SetIsChangedBySwitch(true);
+      Y->SetIsChangedBySwitch(true);
+
+      X->SetODEIndex(0);
+      Y->SetODEIndex(1);
+
+      _p1Formula = new ExplicitFormulaExtender();
+      _p1Formula->AddTimeReference();
+      _p1Formula->AddSpeciesReference(X);
+      _p1Formula->SetEquation(std::string(csTime) + "+x");
+
+      _formula.AddParameterReference("p1", _p1Formula);
+      _formula.AddParameterReference("p2", FormatNumber(_p2));
+   }
+};
+
+TEST_F(when_creating_for_parameter_species_and_time, should_calculate_correct_value_without_simplifying)
+{
+   _p1Formula->Finalize();
+   _formula.Finalize();
+
+   double yy[2] = {_x, _y}, time = 17.5;
+
+   double p1 = _p1Formula->DE_Compute(yy, time, USE_SCALEFACTOR);
+   EXPECT_DOUBLE_EQ(time + _x, p1);
+
+   double value = _formula.DE_Compute(yy, time, USE_SCALEFACTOR);
+   EXPECT_DOUBLE_EQ(p1 * _x + _p2 * _y, value);
+}
+
+TEST_F(when_creating_for_parameter_species_and_time, should_calculate_correct_value_with_simplifying)
+{
+   EXPECT_FALSE(_p1Formula->Simplify(false));
+   EXPECT_FALSE(_formula.Simplify(false));
+
+   _p1Formula->Finalize();
+   _formula.Finalize();
+
+   double yy[2] = {_x, _y}, time = 17.5;
+
+   double p1 = _p1Formula->DE_Compute(yy, time, USE_SCALEFACTOR);
+   EXPECT_DOUBLE_EQ(time + _x, p1);
+
+   double value = _formula.DE_Compute(yy, time, USE_SCALEFACTOR);
+   EXPECT_DOUBLE_EQ(p1 * _x + _p2 * _y, value);
+}
+
+class when_getting_switch_timepoints : public ::testing::Test
+{
+protected:
+   ExplicitFormulaExtender _formula;
+   ExplicitFormulaExtender* _p1Formula = nullptr;
+   ExplicitFormulaExtender* _p2Formula = nullptr;
+
+   void SetUp() override
+   {
+      // Setup for returning time points 1,2,3,4,5,6,7
+      _formula.SetEquation("((p1>=2) AND (Time>3)) OR ((4=Time) OR (Time !=2) OR (Time<>1)) AND NOT ((Time>=p1) OR (Time<p2) OR (Time<=5) OR (Time<=x))");
+      _formula.AddTimeReference();
+
+      SpeciesExtender* X = _formula.AddSpeciesReference("x", "-1");
+      X->SetIsChangedBySwitch(true);
+
+      _p1Formula = new ExplicitFormulaExtender();
+      _p1Formula->SetEquation("6");
+      _formula.AddParameterReference("p1", _p1Formula, true);
+
+      _p2Formula = new ExplicitFormulaExtender();
+      _p2Formula->SetEquation("7");
+      _formula.AddParameterReference("p2", _p2Formula, true);
+   }
+};
+
+TEST_F(when_getting_switch_timepoints, should_return_correct_switch_timepoints)
+{
+   _p1Formula->Simplify(false);
+   _p2Formula->Simplify(false);
+   _formula.Simplify(false);
+
+   _p1Formula->Finalize();
+   _p2Formula->Finalize();
+   _formula.Finalize();
+
+   std::vector<double> switchTimePoints = _formula.SwitchTimePoints();
+
+   ASSERT_EQ((size_t)7, switchTimePoints.size());
+
+   DoubleQueue dq;
+   for (size_t i = 0; i < switchTimePoints.size(); i++)
+      dq.push(switchTimePoints[i]);
+
+   for (int i = 1; i <= 7; i++)
+   {
+      EXPECT_DOUBLE_EQ((double)i, dq.top());
+      dq.pop();
+   }
+}

--- a/tests/OSPSuite.SimModelNative.Tests/src/OutputSchemaSpecs.cpp
+++ b/tests/OSPSuite.SimModelNative.Tests/src/OutputSchemaSpecs.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 #include "SimModel/OutputSchema.h"
+#include "SimModel/SimModelTypeDefs.h"
+#include "SimModel/TObjectVector.h"
 #include <ErrorData.h>
 
 using namespace SimModelNative;
@@ -126,4 +128,26 @@ TEST(when_getting_time_points_for_an_equidistant_interval_with_three_points, sho
    EXPECT_DOUBLE_EQ(0.0, points[0]);
    EXPECT_DOUBLE_EQ(0.5, points[1]);
    EXPECT_DOUBLE_EQ(1.0, points[2]);
+}
+
+// --- OutputSchema::AllTimePoints (migrated from the original C++/CLI specs) ---
+
+TEST(when_retrieving_points_from_output_schema_with_overlapping_intervals, should_retrieve_all_unique_points_in_increasing_order)
+{
+   OutputSchema schema;
+
+   TObjectVector<OutputInterval>& intervals = schema.OutputIntervals();
+   intervals.push_back(new OutputInterval(10, 20, 3, Equidistant)); // 10, 15, 20
+   intervals.push_back(new OutputInterval(20, 30, 3, Equidistant)); // 20, 25, 30
+   intervals.push_back(new OutputInterval(0, 10, 3, Equidistant));  // 0, 5, 10
+
+   DoubleQueue timePointsQueue = schema.AllTimePoints<float>();
+
+   // should return [0 5 10 15 20 25 30]
+   ASSERT_EQ((size_t)7, timePointsQueue.size());
+   for (int i = 0; i <= 6; i++)
+   {
+      EXPECT_DOUBLE_EQ(5.0 * i, timePointsQueue.top());
+      timePointsQueue.pop();
+   }
 }

--- a/tests/OSPSuite.SimModelNative.Tests/src/ParameterSpecs.cpp
+++ b/tests/OSPSuite.SimModelNative.Tests/src/ParameterSpecs.cpp
@@ -1,0 +1,96 @@
+#include <gtest/gtest.h>
+#include "SimModel/Parameter.h"
+#include "SimModel/ExplicitFormula.h"
+#include "SimModel/TableFormula.h"
+#include "SimModel/SimModelTypeDefs.h"
+#include "SimModel/GlobalConstants.h"
+#include "SimModel/Formula.h"
+#include <ErrorData.h>
+#include <vector>
+
+using namespace SimModelNative;
+
+class when_setting_table_points_into_nontable_parameter : public ::testing::Test
+{
+protected:
+   Parameter _parameter;
+
+   void SetUp() override
+   {
+      _parameter.SetFormula(new ExplicitFormula());
+
+      std::vector<ValuePoint> valuePoints;
+      valuePoints.push_back(ValuePoint(0, 0, false));
+      valuePoints.push_back(ValuePoint(1, 2, false));
+      valuePoints.push_back(ValuePoint(5, 3, true));
+      valuePoints.push_back(ValuePoint(20, 6, false));
+      valuePoints.push_back(ValuePoint(40, 6, false));
+      valuePoints.push_back(ValuePoint(41, 8, false));
+
+      _parameter.SetTablePoints(valuePoints);
+   }
+
+   double Calculate(double time)
+   {
+      return _parameter.GetValue(nullptr, time, USE_SCALEFACTOR);
+   }
+};
+
+TEST_F(when_setting_table_points_into_nontable_parameter, parameter_should_be_table)
+{
+   EXPECT_TRUE(_parameter.IsTable());
+}
+
+TEST_F(when_setting_table_points_into_nontable_parameter, should_calculate_correct_value)
+{
+   EXPECT_DOUBLE_EQ(0.0, Calculate(-1));
+   EXPECT_DOUBLE_EQ(0.0, Calculate(0));
+   EXPECT_DOUBLE_EQ(1.0, Calculate(0.5));
+   EXPECT_DOUBLE_EQ(2.0, Calculate(1));
+   EXPECT_DOUBLE_EQ(2.5, Calculate(3));
+   EXPECT_DOUBLE_EQ(3.0, Calculate(5));
+   EXPECT_DOUBLE_EQ(4.0, Calculate(10));
+   EXPECT_DOUBLE_EQ(6.0, Calculate(20));
+   EXPECT_DOUBLE_EQ(6.0, Calculate(30));
+   EXPECT_DOUBLE_EQ(6.0, Calculate(40));
+   EXPECT_DOUBLE_EQ(7.0, Calculate(40.5));
+   EXPECT_DOUBLE_EQ(8.0, Calculate(42));
+}
+
+class when_setting_initial_value_into_table_parameter : public ::testing::Test
+{
+protected:
+   static constexpr double _initialValue = 999;
+
+   Parameter _parameter;
+
+   void SetUp() override
+   {
+      _parameter.SetFormula(new TableFormula());
+
+      std::vector<ValuePoint> valuePoints;
+      valuePoints.push_back(ValuePoint(0, 0, false));
+      valuePoints.push_back(ValuePoint(1, 2, false));
+
+      _parameter.SetTablePoints(valuePoints);
+
+      _parameter.SetInitialValue(_initialValue);
+   }
+
+   double Calculate(double time)
+   {
+      return _parameter.GetValue(nullptr, time, USE_SCALEFACTOR);
+   }
+};
+
+TEST_F(when_setting_initial_value_into_table_parameter, parameter_should_not_be_table)
+{
+   EXPECT_FALSE(_parameter.IsTable());
+}
+
+TEST_F(when_setting_initial_value_into_table_parameter, should_calculate_correct_value)
+{
+   EXPECT_DOUBLE_EQ(_initialValue, Calculate(-1));
+   EXPECT_DOUBLE_EQ(_initialValue, Calculate(0));
+   EXPECT_DOUBLE_EQ(_initialValue, Calculate(2));
+}

--- a/tests/OSPSuite.SimModelNative.Tests/src/RcmSpecs.cpp
+++ b/tests/OSPSuite.SimModelNative.Tests/src/RcmSpecs.cpp
@@ -5,6 +5,16 @@
 
 using namespace SimModelNative;
 
+// Provide access to the protected createAdjacencyInfo method via public inheritance.
+class RcmExtender : public Rcm
+{
+public:
+   void createAdjacencyInfo(std::vector<std::vector<bool>>& matrix, int& adjacencyNumber, int*& adj, int*& adj_row)
+   {
+      Rcm::createAdjacencyInfo(matrix, adjacencyNumber, adj, adj_row);
+   }
+};
+
 class when_testing_rcm : public ::testing::Test
 {
 protected:
@@ -13,6 +23,23 @@ protected:
    std::vector<std::vector<bool>> createMatrix(int n) const
    {
       return std::vector<std::vector<bool>>(n, std::vector<bool>(n, false));
+   }
+
+   // The 10x10 example documented in Rcm.h, also used by the original C++/CLI specs.
+   std::vector<std::vector<bool>> createTenNodeMatrix() const
+   {
+      auto matrix = createMatrix(10);
+      matrix[0][3] = true; matrix[0][5] = true;
+      matrix[1][2] = true; matrix[1][4] = true; matrix[1][6] = true; matrix[1][9] = true;
+      matrix[2][1] = true; matrix[2][3] = true; matrix[2][4] = true;
+      matrix[3][0] = true; matrix[3][2] = true; matrix[3][5] = true; matrix[3][8] = true;
+      matrix[4][1] = true; matrix[4][2] = true; matrix[4][6] = true;
+      matrix[5][0] = true; matrix[5][3] = true; matrix[5][6] = true; matrix[5][7] = true;
+      matrix[6][1] = true; matrix[6][4] = true; matrix[6][5] = true; matrix[6][7] = true;
+      matrix[7][5] = true; matrix[7][6] = true;
+      matrix[8][3] = true;
+      matrix[9][1] = true;
+      return matrix;
    }
 
    void verifyPermutation(const std::vector<unsigned int>& perm, unsigned int n) const
@@ -139,3 +166,57 @@ TEST_F(when_testing_rcm, should_return_valid_permutation_for_star_graph)
    auto perm = rcm.GenRcm(matrix);
    verifyPermutation(perm, 5);
 }
+
+// --- Migrated from the original C++/CLI RcmSpecs.cpp ---------------------------
+
+TEST_F(when_testing_rcm, should_create_proper_rcm_inputs)
+{
+   auto matrix = createTenNodeMatrix();
+
+   RcmExtender rcmExtender;
+   int adjacencyNumber = 0;
+   int* adj = nullptr;
+   int* adj_row = nullptr;
+
+   rcmExtender.createAdjacencyInfo(matrix, adjacencyNumber, adj, adj_row);
+
+   // expected outputs for the adjacency info (1-based indices)
+   const int adj_save[28] = {
+      4, 6,
+      3, 5, 7, 10,
+      2, 4, 5,
+      1, 3, 6, 9,
+      2, 3, 7,
+      1, 4, 7, 8,
+      2, 5, 6, 8,
+      6, 7,
+      4,
+      2};
+
+   const int adj_row_save[11] = {1, 3, 7, 10, 14, 17, 21, 25, 27, 28, 29};
+
+   EXPECT_EQ(28, adjacencyNumber);
+
+   for (int i = 0; i < 28; i++)
+      EXPECT_EQ(adj_save[i], adj[i]);
+
+   for (int i = 0; i < 11; i++)
+      EXPECT_EQ(adj_row_save[i], adj_row[i]);
+
+   delete[] adj;
+   delete[] adj_row;
+}
+
+TEST_F(when_testing_rcm, should_return_correct_permutation_for_ten_node_example)
+{
+   auto matrix = createTenNodeMatrix();
+
+   auto permutation = rcm.GenRcm(matrix);
+
+   const unsigned int permutation_save[10] = {8, 0, 7, 5, 3, 6, 4, 2, 1, 9};
+
+   ASSERT_EQ(10u, permutation.size());
+   for (int i = 0; i < 10; i++)
+      EXPECT_EQ(permutation_save[i], permutation[i]);
+}
+

--- a/tests/OSPSuite.SimModelNative.Tests/src/RcmSpecs.cpp
+++ b/tests/OSPSuite.SimModelNative.Tests/src/RcmSpecs.cpp
@@ -103,28 +103,7 @@ TEST_F(when_testing_rcm, should_return_valid_permutation_for_line_graph)
 TEST_F(when_testing_rcm, should_return_valid_permutation_for_ten_node_example)
 {
    // The 10x10 example from the header documentation
-   auto matrix = createMatrix(10);
-
-   // Row 0: connected to 3, 5
-   matrix[0][3] = true; matrix[0][5] = true;
-   // Row 1: connected to 2, 4, 6, 9
-   matrix[1][2] = true; matrix[1][4] = true; matrix[1][6] = true; matrix[1][9] = true;
-   // Row 2: connected to 1, 3, 4
-   matrix[2][1] = true; matrix[2][3] = true; matrix[2][4] = true;
-   // Row 3: connected to 0, 2, 5, 8
-   matrix[3][0] = true; matrix[3][2] = true; matrix[3][5] = true; matrix[3][8] = true;
-   // Row 4: connected to 1, 2, 6
-   matrix[4][1] = true; matrix[4][2] = true; matrix[4][6] = true;
-   // Row 5: connected to 0, 3, 6, 7
-   matrix[5][0] = true; matrix[5][3] = true; matrix[5][6] = true; matrix[5][7] = true;
-   // Row 6: connected to 1, 4, 5, 7
-   matrix[6][1] = true; matrix[6][4] = true; matrix[6][5] = true; matrix[6][7] = true;
-   // Row 7: connected to 5, 6
-   matrix[7][5] = true; matrix[7][6] = true;
-   // Row 8: connected to 3
-   matrix[8][3] = true;
-   // Row 9: connected to 1
-   matrix[9][1] = true;
+   auto matrix = createTenNodeMatrix();
 
    auto perm = rcm.GenRcm(matrix);
    verifyPermutation(perm, 10);

--- a/tests/OSPSuite.SimModelNative.Tests/src/SimulationTaskSpecs.cpp
+++ b/tests/OSPSuite.SimModelNative.Tests/src/SimulationTaskSpecs.cpp
@@ -1,0 +1,214 @@
+#include <gtest/gtest.h>
+#include "SimModel/SimulationTask.h"
+#include "SimModel/OutputSchema.h"
+#include "SimModel/SimModelTypeDefs.h"
+#include <vector>
+
+using namespace SimModelNative;
+
+// Provide access to the protected static OutputTimePoints overload via public inheritance.
+class SimulationTaskExtender : public SimulationTask
+{
+public:
+   static std::vector<OutputTimePoint> OutputTimePoints(DoubleQueue userOutputTimePoints,
+                                                        DoubleQueue switchTimePoints,
+                                                        DoubleQueue tableFormulaRestartTimePoints,
+                                                        double simulationStartTime)
+   {
+      return SimulationTask::OutputTimePoints(userOutputTimePoints,
+                                              switchTimePoints,
+                                              tableFormulaRestartTimePoints,
+                                              simulationStartTime);
+   }
+};
+
+class when_creating_timepoint_list : public ::testing::Test
+{
+protected:
+   double _t0 = 0.0;
+
+   void CheckTimePoints(const std::vector<OutputTimePoint>& outputTimePoints, unsigned int size,
+                        const double times[], const bool saveSolution[],
+                        const bool isSwitchTimePoint[], const bool restartNeeded[])
+   {
+      ASSERT_EQ((size_t)size, outputTimePoints.size());
+
+      for (unsigned int i = 0; i < outputTimePoints.size(); i++)
+      {
+         EXPECT_DOUBLE_EQ(times[i], outputTimePoints[i].Time());
+         EXPECT_EQ(saveSolution[i], outputTimePoints[i].SaveSystemSolution());
+         EXPECT_EQ(isSwitchTimePoint[i], outputTimePoints[i].IsSwitchTimePoint());
+         EXPECT_EQ(restartNeeded[i], outputTimePoints[i].RestartSystem());
+      }
+   }
+};
+
+TEST_F(when_creating_timepoint_list, should_return_usertimepoints_for_empty_switch_timepoints)
+{
+   DoubleQueue userOutputTimePoints;
+   DoubleQueue switchTimePoints;
+   DoubleQueue tableFormulaRestartTimePoints;
+
+   userOutputTimePoints.push(10);
+   userOutputTimePoints.push(30);
+   userOutputTimePoints.push(20);
+
+   std::vector<OutputTimePoint> outputTimePoints =
+      SimulationTaskExtender::OutputTimePoints(userOutputTimePoints, switchTimePoints, tableFormulaRestartTimePoints, _t0);
+
+   ASSERT_EQ(userOutputTimePoints.size(), outputTimePoints.size());
+
+   for (unsigned int i = 0; i < outputTimePoints.size(); i++)
+   {
+      EXPECT_DOUBLE_EQ(userOutputTimePoints.top(), outputTimePoints[i].Time());
+      EXPECT_TRUE(outputTimePoints[i].SaveSystemSolution());
+      EXPECT_FALSE(outputTimePoints[i].IsSwitchTimePoint());
+
+      userOutputTimePoints.pop();
+   }
+}
+
+TEST_F(when_creating_timepoint_list, should_return_correct_timepoints_1)
+{
+   // first relevant switch point after first relevant user timepoint
+   // last relevant switch point before last relevant user timepoint
+   DoubleQueue userOutputTimePoints;
+   DoubleQueue switchTimePoints;
+   DoubleQueue tableFormulaRestartTimePoints;
+
+   userOutputTimePoints.push(_t0 - 5);
+   userOutputTimePoints.push(_t0 + 10);
+   userOutputTimePoints.push(_t0 + 30);
+   userOutputTimePoints.push(_t0 + 20);
+
+   switchTimePoints.push(_t0 - 3);
+   switchTimePoints.push(_t0 + 15);
+   switchTimePoints.push(_t0 + 25);
+
+   tableFormulaRestartTimePoints.push(_t0 + 28);
+   tableFormulaRestartTimePoints.push(_t0 + 25);
+
+   double times[] =             {_t0 + 10, _t0 + 15, _t0 + 20, _t0 + 25, _t0 + 28, _t0 + 30};
+   bool saveSolution[] =        {true,     false,    true,     false,    false,    true};
+   bool isSwitchTimePoint[] =   {false,    true,     false,    true,     true,     false};
+   bool restart[] =             {false,    false,    false,    true,     true,     false};
+
+   std::vector<OutputTimePoint> outputTimePoints =
+      SimulationTaskExtender::OutputTimePoints(userOutputTimePoints, switchTimePoints, tableFormulaRestartTimePoints, _t0);
+
+   CheckTimePoints(outputTimePoints, 6, times, saveSolution, isSwitchTimePoint, restart);
+
+   EXPECT_EQ(3, SimulationTask::NumberOfSimulatedTimeSteps(outputTimePoints));
+}
+
+TEST_F(when_creating_timepoint_list, should_return_correct_timepoints_2)
+{
+   // first relevant switch point = first relevant user timepoint
+   // last relevant switch point before last relevant user timepoint
+   DoubleQueue userOutputTimePoints;
+   DoubleQueue switchTimePoints;
+   DoubleQueue tableFormulaRestartTimePoints;
+
+   userOutputTimePoints.push(_t0 - 5);
+   userOutputTimePoints.push(_t0 + 10);
+   userOutputTimePoints.push(_t0 + 30);
+   userOutputTimePoints.push(_t0 + 20);
+
+   switchTimePoints.push(_t0 - 3);
+   switchTimePoints.push(_t0 + 10);
+   switchTimePoints.push(_t0 + 25);
+
+   double times[] =             {_t0 + 10, _t0 + 20, _t0 + 25, _t0 + 30};
+   bool saveSolution[] =        {true,     true,     false,    true};
+   bool isSwitchTimePoint[] =   {true,     false,    true,     false};
+   bool restart[] =             {false,    false,    false,    false};
+
+   std::vector<OutputTimePoint> outputTimePoints =
+      SimulationTaskExtender::OutputTimePoints(userOutputTimePoints, switchTimePoints, tableFormulaRestartTimePoints, _t0);
+
+   CheckTimePoints(outputTimePoints, 4, times, saveSolution, isSwitchTimePoint, restart);
+}
+
+TEST_F(when_creating_timepoint_list, should_return_correct_timepoints_3)
+{
+   // first relevant switch point before first relevant user timepoint
+   // last relevant switch point before last relevant user timepoint
+   DoubleQueue userOutputTimePoints;
+   DoubleQueue switchTimePoints;
+   DoubleQueue tableFormulaRestartTimePoints;
+
+   userOutputTimePoints.push(_t0 - 5);
+   userOutputTimePoints.push(_t0 + 10);
+   userOutputTimePoints.push(_t0 + 30);
+   userOutputTimePoints.push(_t0 + 20);
+
+   switchTimePoints.push(_t0 - 3);
+   switchTimePoints.push(_t0 + 5);
+   switchTimePoints.push(_t0 + 25);
+
+   double times[] =             {_t0 + 5, _t0 + 10, _t0 + 20, _t0 + 25, _t0 + 30};
+   bool saveSolution[] =        {false,   true,     true,     false,    true};
+   bool isSwitchTimePoint[] =   {true,    false,    false,    true,     false};
+   bool restart[] =             {false,   false,    false,    false,    false};
+
+   std::vector<OutputTimePoint> outputTimePoints =
+      SimulationTaskExtender::OutputTimePoints(userOutputTimePoints, switchTimePoints, tableFormulaRestartTimePoints, _t0);
+
+   CheckTimePoints(outputTimePoints, 5, times, saveSolution, isSwitchTimePoint, restart);
+}
+
+TEST_F(when_creating_timepoint_list, should_return_correct_timepoints_4)
+{
+   // first relevant switch point after first relevant user timepoint
+   // last relevant switch point = last relevant user timepoint
+   DoubleQueue userOutputTimePoints;
+   DoubleQueue switchTimePoints;
+   DoubleQueue tableFormulaRestartTimePoints;
+
+   userOutputTimePoints.push(_t0 - 5);
+   userOutputTimePoints.push(_t0 + 10);
+   userOutputTimePoints.push(_t0 + 30);
+   userOutputTimePoints.push(_t0 + 20);
+
+   switchTimePoints.push(_t0 - 3);
+   switchTimePoints.push(_t0 + 15);
+   switchTimePoints.push(_t0 + 30);
+
+   double times[] =             {_t0 + 10, _t0 + 15, _t0 + 20, _t0 + 30};
+   bool saveSolution[] =        {true,     false,    true,     true};
+   bool isSwitchTimePoint[] =   {false,    true,     false,    true};
+   bool restart[] =             {false,    false,    false,    false};
+
+   std::vector<OutputTimePoint> outputTimePoints =
+      SimulationTaskExtender::OutputTimePoints(userOutputTimePoints, switchTimePoints, tableFormulaRestartTimePoints, _t0);
+
+   CheckTimePoints(outputTimePoints, 4, times, saveSolution, isSwitchTimePoint, restart);
+}
+
+TEST_F(when_creating_timepoint_list, should_return_correct_timepoints_5)
+{
+   // first relevant switch point after first relevant user timepoint
+   // last relevant switch point after last relevant user timepoint
+   DoubleQueue userOutputTimePoints;
+   DoubleQueue switchTimePoints;
+   DoubleQueue tableFormulaRestartTimePoints;
+
+   userOutputTimePoints.push(_t0 - 5);
+   userOutputTimePoints.push(_t0 + 10);
+   userOutputTimePoints.push(_t0 + 30);
+   userOutputTimePoints.push(_t0 + 20);
+
+   switchTimePoints.push(_t0 - 3);
+   switchTimePoints.push(_t0 + 15);
+   switchTimePoints.push(_t0 + 35);
+
+   double times[] =             {_t0 + 10, _t0 + 15, _t0 + 20, _t0 + 30};
+   bool saveSolution[] =        {true,     false,    true,     true};
+   bool isSwitchTimePoint[] =   {false,    true,     false,    false};
+   bool restart[] =             {false,    false,    false,    false};
+
+   std::vector<OutputTimePoint> outputTimePoints =
+      SimulationTaskExtender::OutputTimePoints(userOutputTimePoints, switchTimePoints, tableFormulaRestartTimePoints, _t0);
+
+   CheckTimePoints(outputTimePoints, 4, times, saveSolution, isSwitchTimePoint, restart);
+}

--- a/tests/OSPSuite.SimModelNative.Tests/src/TableFormulaSpecs.cpp
+++ b/tests/OSPSuite.SimModelNative.Tests/src/TableFormulaSpecs.cpp
@@ -3,24 +3,16 @@
 #include "SimModel/SimModelTypeDefs.h"
 #include "SimModel/GlobalConstants.h"
 #include "SimModel/TObjectVector.h"
+#include "TableFormulaTestExtender.h"
 #include <ErrorData.h>
 #include <vector>
 
 using namespace SimModelNative;
 
-// Provide access to protected members of TableFormula via public inheritance.
-// (Originally implemented in the C++/CLI helper TableFormulaSpecsHelper.h.)
-class TableFormulaExtender : public TableFormula
-{
-public:
-   TObjectVector<ValuePoint>& ValuePoints() { return _valuePoints; }
-   void CallCacheValues() { CacheValues(); }
-};
-
 class when_creating_for_given_table : public ::testing::Test
 {
 protected:
-   TableFormulaExtender _formula;
+   TableFormulaTestExtender _formula;
 
    void SetUp() override
    {

--- a/tests/OSPSuite.SimModelNative.Tests/src/TableFormulaSpecs.cpp
+++ b/tests/OSPSuite.SimModelNative.Tests/src/TableFormulaSpecs.cpp
@@ -1,0 +1,68 @@
+#include <gtest/gtest.h>
+#include "SimModel/TableFormula.h"
+#include "SimModel/SimModelTypeDefs.h"
+#include "SimModel/GlobalConstants.h"
+#include "SimModel/TObjectVector.h"
+#include <ErrorData.h>
+#include <vector>
+
+using namespace SimModelNative;
+
+// Provide access to protected members of TableFormula via public inheritance.
+// (Originally implemented in the C++/CLI helper TableFormulaSpecsHelper.h.)
+class TableFormulaExtender : public TableFormula
+{
+public:
+   TObjectVector<ValuePoint>& ValuePoints() { return _valuePoints; }
+   void CallCacheValues() { CacheValues(); }
+};
+
+class when_creating_for_given_table : public ::testing::Test
+{
+protected:
+   TableFormulaExtender _formula;
+
+   void SetUp() override
+   {
+      TObjectVector<ValuePoint>& valuePoints = _formula.ValuePoints();
+      valuePoints.push_back(new ValuePoint(0, 0, false));
+      valuePoints.push_back(new ValuePoint(1, 2, false));
+      valuePoints.push_back(new ValuePoint(5, 3, true));
+      valuePoints.push_back(new ValuePoint(20, 6, false));
+      valuePoints.push_back(new ValuePoint(40, 6, false));
+      valuePoints.push_back(new ValuePoint(41, 8, false));
+
+      _formula.CallCacheValues();
+   }
+
+   double Calculate(double x)
+   {
+      return _formula.DE_Compute(nullptr, x, USE_SCALEFACTOR);
+   }
+};
+
+TEST_F(when_creating_for_given_table, should_calculate_correct_value)
+{
+   EXPECT_DOUBLE_EQ(0.0, Calculate(-1));
+   EXPECT_DOUBLE_EQ(2.0, Calculate(0));
+   EXPECT_DOUBLE_EQ(2.0, Calculate(0.5));
+   EXPECT_DOUBLE_EQ(0.25, Calculate(1));
+   EXPECT_DOUBLE_EQ(0.25, Calculate(3));
+   EXPECT_DOUBLE_EQ(0.2, Calculate(5));
+   EXPECT_DOUBLE_EQ(0.2, Calculate(10));
+   EXPECT_DOUBLE_EQ(0.0, Calculate(20));
+   EXPECT_DOUBLE_EQ(0.0, Calculate(30));
+   EXPECT_DOUBLE_EQ(2.0, Calculate(40));
+   EXPECT_DOUBLE_EQ(2.0, Calculate(40.5));
+   EXPECT_DOUBLE_EQ(0.0, Calculate(42));
+}
+
+TEST_F(when_creating_for_given_table, should_set_restart_timepoints)
+{
+   std::vector<double> restartTimePoints = _formula.RestartTimePoints();
+
+   ASSERT_EQ(3u, restartTimePoints.size());
+   EXPECT_DOUBLE_EQ(0.0, restartTimePoints[0]);
+   EXPECT_DOUBLE_EQ(5.0, restartTimePoints[1]);
+   EXPECT_DOUBLE_EQ(40.0, restartTimePoints[2]);
+}

--- a/tests/OSPSuite.SimModelNative.Tests/src/TableFormulaTestExtender.h
+++ b/tests/OSPSuite.SimModelNative.Tests/src/TableFormulaTestExtender.h
@@ -1,0 +1,20 @@
+#ifndef _TableFormulaTestExtender_H_
+#define _TableFormulaTestExtender_H_
+
+#include "SimModel/TableFormula.h"
+#include "SimModel/TObjectVector.h"
+
+namespace SimModelNative
+{
+   // Provide access to protected members of TableFormula via public inheritance.
+   // (Originally implemented in the C++/CLI helper TableFormulaSpecsHelper.h.)
+   // Shared across the TableFormula spec files to avoid duplicating the wrapper.
+   class TableFormulaTestExtender : public TableFormula
+   {
+   public:
+      TObjectVector<ValuePoint>& ValuePoints() { return _valuePoints; }
+      void CallCacheValues() { CacheValues(); }
+   };
+}
+
+#endif //_TableFormulaTestExtender_H_

--- a/tests/OSPSuite.SimModelNative.Tests/src/TableFormulaWithOffsetSpecs.cpp
+++ b/tests/OSPSuite.SimModelNative.Tests/src/TableFormulaWithOffsetSpecs.cpp
@@ -6,18 +6,11 @@
 #include "SimModel/SimModelTypeDefs.h"
 #include "SimModel/GlobalConstants.h"
 #include "SimModel/TObjectVector.h"
+#include "TableFormulaTestExtender.h"
 #include <ErrorData.h>
 #include <vector>
 
 using namespace SimModelNative;
-
-// Provide access to protected members of TableFormula via public inheritance.
-class TableFormulaForOffsetExtender : public TableFormula
-{
-public:
-   TObjectVector<ValuePoint>& ValuePoints() { return _valuePoints; }
-   void CallCacheValues() { CacheValues(); }
-};
 
 // Provide access to protected members of TableFormulaWithOffset via public inheritance.
 class TableFormulaWithOffsetExtender : public TableFormulaWithOffset
@@ -34,7 +27,7 @@ protected:
    static constexpr double _offset = 300.0;
 
    TableFormulaWithOffsetExtender _formula;
-   TableFormulaForOffsetExtender _tableFormula;
+   TableFormulaTestExtender _tableFormula;
    Parameter _offsetObject;
    Parameter _tableObject;
 

--- a/tests/OSPSuite.SimModelNative.Tests/src/TableFormulaWithOffsetSpecs.cpp
+++ b/tests/OSPSuite.SimModelNative.Tests/src/TableFormulaWithOffsetSpecs.cpp
@@ -1,0 +1,91 @@
+#include <gtest/gtest.h>
+#include "SimModel/TableFormula.h"
+#include "SimModel/TableFormulaWithOffset.h"
+#include "SimModel/Parameter.h"
+#include "SimModel/Quantity.h"
+#include "SimModel/SimModelTypeDefs.h"
+#include "SimModel/GlobalConstants.h"
+#include "SimModel/TObjectVector.h"
+#include <ErrorData.h>
+#include <vector>
+
+using namespace SimModelNative;
+
+// Provide access to protected members of TableFormula via public inheritance.
+class TableFormulaForOffsetExtender : public TableFormula
+{
+public:
+   TObjectVector<ValuePoint>& ValuePoints() { return _valuePoints; }
+   void CallCacheValues() { CacheValues(); }
+};
+
+// Provide access to protected members of TableFormulaWithOffset via public inheritance.
+class TableFormulaWithOffsetExtender : public TableFormulaWithOffset
+{
+public:
+   void SetTableObject(Quantity* tableObject) { _tableObject = tableObject; }
+   void SetOffsetObject(Quantity* offsetObject) { _offsetObject = offsetObject; }
+   void SetTableFormula(TableFormula* tableFormula) { _tableFormula = tableFormula; }
+};
+
+class when_creating_for_given_table_with_offset : public ::testing::Test
+{
+protected:
+   static constexpr double _offset = 300.0;
+
+   TableFormulaWithOffsetExtender _formula;
+   TableFormulaForOffsetExtender _tableFormula;
+   Parameter _offsetObject;
+   Parameter _tableObject;
+
+   void SetUp() override
+   {
+      TObjectVector<ValuePoint>& valuePoints = _tableFormula.ValuePoints();
+      valuePoints.push_back(new ValuePoint(0, 0, false));
+      valuePoints.push_back(new ValuePoint(1, 2, false));
+      valuePoints.push_back(new ValuePoint(5, 3, true));
+      valuePoints.push_back(new ValuePoint(20, 6, false));
+      valuePoints.push_back(new ValuePoint(40, 6, false));
+      valuePoints.push_back(new ValuePoint(41, 8, false));
+
+      _tableFormula.CallCacheValues();
+
+      _offsetObject.SetConstantValue(_offset);
+      _formula.SetOffsetObject(&_offsetObject);
+      _formula.SetTableFormula(&_tableFormula);
+
+      _tableObject.SetFormula(&_tableFormula);
+      _formula.SetTableObject(&_tableObject);
+   }
+
+   double Calculate(double x)
+   {
+      return _formula.DE_Compute(nullptr, x, USE_SCALEFACTOR);
+   }
+};
+
+TEST_F(when_creating_for_given_table_with_offset, should_calculate_correct_value)
+{
+   EXPECT_DOUBLE_EQ(0.0, Calculate(-1 + _offset));
+   EXPECT_DOUBLE_EQ(2.0, Calculate(0 + _offset));
+   EXPECT_DOUBLE_EQ(2.0, Calculate(0.5 + _offset));
+   EXPECT_DOUBLE_EQ(0.25, Calculate(1 + _offset));
+   EXPECT_DOUBLE_EQ(0.25, Calculate(3 + _offset));
+   EXPECT_DOUBLE_EQ(0.2, Calculate(5 + _offset));
+   EXPECT_DOUBLE_EQ(0.2, Calculate(10 + _offset));
+   EXPECT_DOUBLE_EQ(0.0, Calculate(20 + _offset));
+   EXPECT_DOUBLE_EQ(0.0, Calculate(30 + _offset));
+   EXPECT_DOUBLE_EQ(2.0, Calculate(40 + _offset));
+   EXPECT_DOUBLE_EQ(2.0, Calculate(40.5 + _offset));
+   EXPECT_DOUBLE_EQ(0.0, Calculate(42 + _offset));
+}
+
+TEST_F(when_creating_for_given_table_with_offset, should_set_restart_timepoints)
+{
+   std::vector<double> restartTimePoints = _formula.RestartTimePoints();
+
+   ASSERT_EQ(3u, restartTimePoints.size());
+   EXPECT_DOUBLE_EQ(0.0 + _offset, restartTimePoints[0]);
+   EXPECT_DOUBLE_EQ(5.0 + _offset, restartTimePoints[1]);
+   EXPECT_DOUBLE_EQ(40.0 + _offset, restartTimePoints[2]);
+}

--- a/tests/OSPSuite.SimModelNative.Tests/src/TableFormulaWithXArgumentSpecs.cpp
+++ b/tests/OSPSuite.SimModelNative.Tests/src/TableFormulaWithXArgumentSpecs.cpp
@@ -6,18 +6,11 @@
 #include "SimModel/SimModelTypeDefs.h"
 #include "SimModel/GlobalConstants.h"
 #include "SimModel/TObjectVector.h"
+#include "TableFormulaTestExtender.h"
 #include <ErrorData.h>
 #include <vector>
 
 using namespace SimModelNative;
-
-// Provide access to protected members of TableFormula via public inheritance.
-class TableFormulaForXArgumentExtender : public TableFormula
-{
-public:
-   TObjectVector<ValuePoint>& ValuePoints() { return _valuePoints; }
-   void CallCacheValues() { CacheValues(); }
-};
 
 // Provide access to protected members of TableFormulaWithXArgument via public inheritance.
 class TableFormulaWithXArgumentExtender : public TableFormulaWithXArgument
@@ -33,7 +26,7 @@ class when_creating_for_given_table_with_non_time_dependent_xargument : public :
 {
 protected:
    TableFormulaWithXArgumentExtender _formula;
-   TableFormulaForXArgumentExtender _tableFormula;
+   TableFormulaTestExtender _tableFormula;
    Parameter _xArgumentObject;
    Parameter _tableObject;
 

--- a/tests/OSPSuite.SimModelNative.Tests/src/TableFormulaWithXArgumentSpecs.cpp
+++ b/tests/OSPSuite.SimModelNative.Tests/src/TableFormulaWithXArgumentSpecs.cpp
@@ -1,0 +1,110 @@
+#include <gtest/gtest.h>
+#include "SimModel/TableFormula.h"
+#include "SimModel/TableFormulaWithXArgument.h"
+#include "SimModel/Parameter.h"
+#include "SimModel/Quantity.h"
+#include "SimModel/SimModelTypeDefs.h"
+#include "SimModel/GlobalConstants.h"
+#include "SimModel/TObjectVector.h"
+#include <ErrorData.h>
+#include <vector>
+
+using namespace SimModelNative;
+
+// Provide access to protected members of TableFormula via public inheritance.
+class TableFormulaForXArgumentExtender : public TableFormula
+{
+public:
+   TObjectVector<ValuePoint>& ValuePoints() { return _valuePoints; }
+   void CallCacheValues() { CacheValues(); }
+};
+
+// Provide access to protected members of TableFormulaWithXArgument via public inheritance.
+class TableFormulaWithXArgumentExtender : public TableFormulaWithXArgument
+{
+public:
+   void SetTableObject(Quantity* tableObject) { _tableObject = tableObject; }
+   void SetXArgumentObject(Quantity* xArgumentObject) { _XArgumentObject = xArgumentObject; }
+   void SetTableFormula(TableFormula* tableFormula) { _tableFormula = tableFormula; }
+   TableFormula* GetTableFormula() { return _tableFormula; }
+};
+
+class when_creating_for_given_table_with_non_time_dependent_xargument : public ::testing::Test
+{
+protected:
+   TableFormulaWithXArgumentExtender _formula;
+   TableFormulaForXArgumentExtender _tableFormula;
+   Parameter _xArgumentObject;
+   Parameter _tableObject;
+
+   void SetUp() override
+   {
+      TObjectVector<ValuePoint>& valuePoints = _tableFormula.ValuePoints();
+      valuePoints.push_back(new ValuePoint(0, 0, false));
+      valuePoints.push_back(new ValuePoint(1, 2, false));
+      valuePoints.push_back(new ValuePoint(5, 3, true));
+      valuePoints.push_back(new ValuePoint(20, 6, false));
+      valuePoints.push_back(new ValuePoint(40, 6, false));
+      valuePoints.push_back(new ValuePoint(41, 8, false));
+
+      _tableFormula.CallCacheValues();
+
+      _formula.SetXArgumentObject(&_xArgumentObject);
+      _formula.SetTableFormula(&_tableFormula);
+
+      _tableObject.SetFormula(&_tableFormula);
+      _formula.SetTableObject(&_tableObject);
+   }
+
+   void UseDerivedValues(bool useDerivedValues)
+   {
+      _formula.GetTableFormula()->SetUseDerivedValues(useDerivedValues);
+   }
+
+   void CheckValue(double xArgument, double expectedValue)
+   {
+      _xArgumentObject.SetConstantValue(xArgument);
+
+      const double dummyTime = 0.0; // time does not matter for an x argument which is not time dependent
+      EXPECT_DOUBLE_EQ(expectedValue, _formula.DE_Compute(nullptr, dummyTime, USE_SCALEFACTOR));
+   }
+};
+
+TEST_F(when_creating_for_given_table_with_non_time_dependent_xargument, should_calculate_correct_values_in_direct_mode)
+{
+   UseDerivedValues(false);
+
+   CheckValue(-1, 0.0);
+   CheckValue(0, 0.0);
+   CheckValue(0.5, 1.0);
+   CheckValue(1, 2.0);
+   CheckValue(3, 2.5);
+   CheckValue(20, 6.0);
+   CheckValue(30, 6.0);
+   CheckValue(40.5, 7.0);
+   CheckValue(41, 8.0);
+   CheckValue(50, 8.0);
+}
+
+TEST_F(when_creating_for_given_table_with_non_time_dependent_xargument, should_calculate_correct_values_in_derived_mode)
+{
+   UseDerivedValues(true);
+   _tableFormula.CallCacheValues();
+
+   CheckValue(-1, 0.0);
+   CheckValue(0, 2.0);
+   CheckValue(0.5, 2.0);
+   CheckValue(1, 0.25);
+   CheckValue(3, 0.25);
+   CheckValue(20, 0.0);
+   CheckValue(30, 0.0);
+   CheckValue(40.5, 2.0);
+   CheckValue(41, 0.0);
+   CheckValue(50, 0.0);
+}
+
+TEST_F(when_creating_for_given_table_with_non_time_dependent_xargument, should_return_empty_restart_timepoints_set)
+{
+   std::vector<double> restartTimePoints = _formula.RestartTimePoints();
+   EXPECT_TRUE(restartTimePoints.empty());
+}

--- a/tests/OSPSuite.SimModelNative.Tests/src/TestEnvironment.cpp
+++ b/tests/OSPSuite.SimModelNative.Tests/src/TestEnvironment.cpp
@@ -1,0 +1,25 @@
+#include <gtest/gtest.h>
+
+// On Windows the XML wrapper uses MSXML6 via COM (CoCreateInstance). Any test
+// that round-trips a formula through the XML layer (e.g. ExplicitFormula parsing)
+// therefore requires COM to be initialized for the current thread. The
+// production executables do this themselves (see TestAppCpp.cpp), but the
+// GoogleTest runner has no such entry point, so we initialize COM once for the
+// whole test process via a global test environment. On non-Windows platforms
+// the XML wrapper uses libxml2 and this is a no-op.
+#ifdef _WINDOWS
+#include <objbase.h>
+
+namespace
+{
+   class ComEnvironment : public ::testing::Environment
+   {
+   public:
+      void SetUp() override { CoInitialize(NULL); }
+      void TearDown() override { CoUninitialize(); }
+   };
+
+   const ::testing::Environment* const _comEnvironment =
+      ::testing::AddGlobalTestEnvironment(new ComEnvironment());
+}
+#endif

--- a/tests/OSPSuite.SimModelNative.Tests/src/TestEnvironment.cpp
+++ b/tests/OSPSuite.SimModelNative.Tests/src/TestEnvironment.cpp
@@ -15,8 +15,20 @@ namespace
    class ComEnvironment : public ::testing::Environment
    {
    public:
-      void SetUp() override { CoInitialize(NULL); }
-      void TearDown() override { CoUninitialize(); }
+      void SetUp() override { _comInitialized = SUCCEEDED(CoInitialize(NULL)); }
+      void TearDown() override
+      {
+         // Only balance a successful CoInitialize. A failed call (e.g.
+         // RPC_E_CHANGED_MODE) must not trigger CoUninitialize.
+         if (_comInitialized)
+         {
+            CoUninitialize();
+            _comInitialized = false;
+         }
+      }
+
+   private:
+      bool _comInitialized = false;
    };
 
    const ::testing::Environment* const _comEnvironment =


### PR DESCRIPTION
Migrates the old C++/CLI unit tests (from commit `d28cbbc`, `tests/OSPSuite.SimModel.Tests/src`) into the new pure-native Google Test project `tests/OSPSuite.SimModelNative.Tests`, without duplicating tests already migrated to C# and without touching other projects.

### New native test files (`src/`)
- `TableFormulaSpecs.cpp`, `TableFormulaWithOffsetSpecs.cpp`, `TableFormulaWithXArgumentSpecs.cpp`
- `ParameterSpecs.cpp`
- `SimulationTaskSpecs.cpp`
- `ExplicitFormulaSpecs.cpp` — `ExplicitFormulaSpecsHelper` extender classes inlined; `XMLHelper::ToString` replaced by a local `FormatNumber()` to avoid pulling in the XML backend.

### Integrated into existing files
- `RcmSpecs.cpp` — added `RcmExtender` (exposes protected `createAdjacencyInfo`) + 2 tests
- `OutputSchemaSpecs.cpp` — added an `AllTimePoints<float>()` overlapping-intervals test

### Helper handling
"...SpecsHelper" files contain no tests; their public-inheritance extenders are inlined into the matching test file. Naming follows existing specs (`TEST_F(when_..., should_...)`).

### Build registration
6 new files registered in `OSPSuite.SimModelNative.Tests.vcxproj` / `.vcxproj.filters` (CMake auto-globs `src/*.cpp`).

### Intentionally not migrated (documented in `MIGRATION_OVERVIEW.md`)
- **`SimulationSpecs.cpp` (78 tests)** — each is already in `SimulationSpecs.cs`, is a managed XML/API-only test, or is an integration test depending on the .NET test-data/reference-comparison harness (`SpecsHelper.cpp`) that has no native equivalent.
- **`SimModelCompSpecs.cpp` (12 tests)** — target the separate `OSPSuite.SimModelComp` project, which the native test project doesn't link; adding them would require modifying other projects.

<details><summary><h1><b>Migration overview</b></h1></summary>

# Migration overview: old C++/CLI tests &rarr; native Google Test

This document tracks the migration of the old C++/CLI unit tests (commit
`d28cbbc01299c08ee773acaa657e1cc2811b20b0`, folder
`tests/OSPSuite.SimModel.Tests/src`) to the new pure-native Google Test
project `tests/OSPSuite.SimModelNative.Tests/src`.

Conventions used for the migrated tests follow the existing native specs
(`TEST(when_doing_something, should_be_this_and_that)` /
`TEST_F(when_..., should_...)`). "Helper" files contain no tests of their own;
their extender classes (public-inheritance accessors for protected members) were
inlined into the corresponding main test file.

Only the native test project (`OSPSuite.SimModelNative.Tests`) was modified. Per
the task constraint, tests that cannot run without modifying other projects were
**not** added.

---

## ExplicitFormulaSpecs.cpp

Migrated to **`src/ExplicitFormulaSpecs.cpp`** (new). The extender classes from
`ExplicitFormulaSpecsHelper.cpp` were inlined. `XMLHelper::ToString` (which pulls
in the XML backend) was replaced by a local `FormatNumber()` helper.

| Old test (context :: method) | Added | Comment |
|---|---|---|
| when_creating_for_references_independent_equation :: should_calculate_correct_value | YES | Free `TEST`. |
| when_creating_for_parameter_and_species_references :: should_calculate_correct_value_without_simplifying | YES | |
| when_creating_for_parameter_and_species_references :: should_calculate_correct_value_with_simplifying | YES | |
| when_creating_for_parameter_species_and_time :: should_calculate_correct_value_without_simplifying | YES | |
| when_creating_for_parameter_species_and_time :: should_calculate_correct_value_with_simplifying | YES | |
| when_getting_switch_timepoints :: should_return_correct_switch_timepoints | YES | |
| when_creating_product_formula (context) | NO | The context contained no `[TestAttribute]` methods in the old file, so there is nothing to migrate. |

## ExplicitFormulaSpecsHelper.cpp

| Old item | Added | Comment |
|---|---|---|
| (extender classes only) | n/a | Contains no tests. Extenders (`ParameterExtender`, `SpeciesExtender`, `QuantityReferenceExtender`, `ExplicitFormulaExtender`) were inlined into `src/ExplicitFormulaSpecs.cpp`. |

## OutputSchemaSpecs.cpp

Integrated into the existing **`src/OutputSchemaSpecs.cpp`**.

| Old test | Added | Comment |
|---|---|---|
| when_retrieving_all_points_from_output_schema_with_overlapping_intervals :: should_retrieve_all_points | YES | Added as `when_retrieving_points_from_output_schema_with_overlapping_intervals / should_retrieve_all_unique_points_in_increasing_order`, exercising `OutputSchema::AllTimePoints<float>()`. |

## ParameterSpecs.cpp

Migrated to **`src/ParameterSpecs.cpp`** (new).

| Old test | Added | Comment |
|---|---|---|
| when_setting_table_points_into_nontable_parameter :: parameter_should_be_table | YES | |
| when_setting_table_points_into_nontable_parameter :: should_calculate_correct_value | YES | Direct-interpolation values (`SetTablePoints` builds a table with `UseDerivedValues=false`). |
| when_setting_initial_value_into_table_parameter :: parameter_should_not_be_table | YES | |
| when_setting_initial_value_into_table_parameter :: should_calculate_correct_value | YES | |

## RcmSpecs.cpp

Integrated into the existing **`src/RcmSpecs.cpp`**. Added an `RcmExtender`
(public accessor for the protected `createAdjacencyInfo`) plus a
`createTenNodeMatrix()` helper.

| Old test | Added | Comment |
|---|---|---|
| should_create_proper_rcm_inputs | YES | |
| should_return_correct_permutation | YES | Added as `should_return_correct_permutation_for_ten_node_example`. |

## SimulationTaskSpecs.cpp

Migrated to **`src/SimulationTaskSpecs.cpp`** (new). A `SimulationTaskExtender`
exposes the protected static `OutputTimePoints`.

| Old test | Added | Comment |
|---|---|---|
| should_return_usertimepoints_for_empty_switch_timepoints | YES | |
| should_return_correct_timepoints_1 | YES | |
| should_return_correct_timepoints_2 | YES | |
| should_return_correct_timepoints_3 | YES | |
| should_return_correct_timepoints_4 | YES | |
| should_return_correct_timepoints_5 | YES | |

## TableFormulaSpecs.cpp

Migrated to **`src/TableFormulaSpecs.cpp`** (new). A `TableFormulaExtender`
exposes `_valuePoints` and `CacheValues`.

| Old test | Added | Comment |
|---|---|---|
| should_calculate_correct_value | YES | |
| should_set_restart_timepoints | YES | |

## TableFormulaWithOffsetSpecs.cpp

Migrated to **`src/TableFormulaWithOffsetSpecs.cpp`** (new).

| Old test | Added | Comment |
|---|---|---|
| should_calculate_correct_value | YES | |
| should_set_restart_timepoints | YES | |

## TableFormulaWithXArgumentSpecs.cpp

Migrated to **`src/TableFormulaWithXArgumentSpecs.cpp`** (new).

| Old test | Added | Comment |
|---|---|---|
| should_calculate_correct_values_in_direct_mode | YES | |
| should_calculate_correct_values_in_derived_mode | YES | |
| should_return_empty_restart_timepoints_set | YES | |

## SpecsHelper.cpp

| Old item | Added | Comment |
|---|---|---|
| (helper code only) | n/a | Contains no tests. This is .NET/managed test-infrastructure (test-data path resolution and result comparison helpers used by `SimulationSpecs.cpp`). It is not migrated; the native project does not have an equivalent simulation/test-data harness. |

## SimModelCompSpecs.cpp

The old `SimModelCompSpecs.cpp` tests the **OSPSuite.SimModelComp** project,
which is a separate project and is **not** linked into the native test project
(`OSPSuite.SimModelNative.Tests`). Adding these tests would require modifying
other projects' build (to link SimModelComp), which the task explicitly
forbids. Per the rule "if because of this constraint any new tests are not
running - do not add them", none were added.

| Old test | Added | Comment |
|---|---|---|
| should_save_only_persistable_variables_and_observers_into_output_table | NO | Tests SimModelComp (not linked by the native test project). |
| should_save_all_variables_and_observers_into_output_table | NO | Tests SimModelComp (not linked). |
| should_perform_two_simulation_runs | NO | Tests SimModelComp (not linked). |
| should_produce_same_results_when_reloaded_from_saved_file (run A) | NO | Tests SimModelComp (not linked). |
| should_perform_simulation_run (run A) | NO | Tests SimModelComp (not linked). |
| should_produce_same_results_when_reloaded_from_saved_file (run B) | NO | Tests SimModelComp (not linked). |
| should_perform_simulation_run (run B) | NO | Tests SimModelComp (not linked). |
| should_solve_example_system_and_return_correct_sensitivity_values | NO | Tests SimModelComp (not linked). |
| should_add_persistable_parameters_as_observers_into_observers_table | NO | Tests SimModelComp (not linked). |
| should_retrieve_version_of_simmodel_and_simmodelcomp | NO | Tests SimModelComp (not linked). |
| should_set_used_in_simulation_flag_correctly | NO | Tests SimModelComp (not linked). |
| should_throw_exception | NO | Tests SimModelComp (not linked). |

## SimModelCompSpecsHelper.cpp

| Old item | Added | Comment |
|---|---|---|
| (helper code only) | n/a | Contains no tests; supports SimModelCompSpecs.cpp, which is out of scope (see above). |

## SimulationSpecs.cpp

These are full simulation **integration** tests (load XML test data &rarr; run
the CVODES solver &rarr; compare against reference results). The large majority
were already migrated to **`tests/OSPSuite.SimModel.Tests/SimulationSpecs.cs`**
and must not be duplicated. The remainder are either managed-only XML/API tests,
or integration tests that depend on the .NET test-data / reference-comparison
harness (`SpecsHelper.cpp`) which has no equivalent in the native test project
and cannot be reproduced without modifying other projects.

**None were added to the native project.** See the per-test comments below.

| Old test (context :: method) | Added | Comment |
|---|---|---|
| when_loading_from_file :: should_be_loaded_from_file | NO | Already in C# (`when_loading_simulation_from_file`). |
| when_loading_from_string :: should_be_loaded_from_file | NO | Already in C# (`when_loading_from_string`). |
| when_loading_and_finalizing_from_file :: should_be_loaded_and_finalized_from_file | NO | Already in C# (`when_loading_simulation_from_file_and_running`). |
| when_loading_finalizing_and_running :: should_perform_simulation_run | NO | Already in C# (`when_loading_simulation_from_file_and_running`). |
| when_loading_finalizing_and_running_band_solver :: should_perform_simulation_run | NO | Integration (band solver) test; needs test-data/reference harness not available in native project. |
| when_running_system_with_all_constant_species_dense :: solver_output_times_should_be_equal_to_output_schema | NO | Already in C# (`when_running_system_with_all_constant_species`). |
| when_running_system_with_all_constant_species_dense :: species_values_should_be_equal_to_initial_value | NO | Already in C# (`when_running_system_with_all_constant_species`). |
| when_running_system_with_all_constant_species_band :: solver_output_times_should_be_equal_to_output_schema | NO | Band variant; integration test, harness not available. |
| when_running_system_with_all_constant_species_band :: species_values_should_be_equal_to_initial_value | NO | Band variant; integration test, harness not available. |
| when_getting_all_parameter_values_and_all_initial_values :: should_return_correct_value_for_dependent_parameters_and_initial_value_before_and_after_changing_of_basis_parameter | NO | Already in C# (`when_getting_all_parameter_values_and_all_initial_values`). |
| when_running_testsystem_06_without_scalefactor_dense :: should_produce_correct_result | NO | Already in C# (`when_running_testsystem_06_without_scale_factor_dense`). |
| when_running_testsystem_06_without_scalefactor_dense :: should_calculate_comparison_threshold | NO | Already in C# (`when_calculating_comparison_threshold`). |
| when_running_testsystem_06_without_scalefactor_band :: should_produce_correct_result | NO | Band variant; integration test, harness not available. |
| when_running_testsystem_06_with_scalefactor_dense :: should_produce_correct_result | NO | Already in C# (`when_running_testsystem_06_with_scale_factor_dense`). |
| when_running_testsystem_06_with_scalefactor_dense :: should_calculate_comparison_threshold | NO | Already in C# (`when_calculating_comparison_threshold`). |
| when_running_testsystem_06_with_scalefactor_band :: should_produce_correct_result | NO | Band variant; integration test, harness not available. |
| when_running_testsystem_06_setting_all_parameters_as_variable_dense :: should_produce_correct_result | NO | Already in C# (`when_running_testsystem_06_setting_all_parameters_as_variable_dense`). |
| when_running_testsystem_06_setting_all_parameters_as_variable_band :: should_produce_correct_result | NO | Band variant; integration test, harness not available. |
| when_running_testsystem_06_new_schema_without_scalefactor :: should_produce_correct_result | NO | Integration test, harness not available. |
| when_running_testsystem_06_new_schema_with_scalefactor :: should_produce_correct_result | NO | Integration test, harness not available. |
| when_running_testsystem_06_modified_setting_parameter_values_and_initial_values :: should_produce_correct_result | NO | Already in C# (`when_running_testsystem_06_modified_setting_parameter_values_and_initial_values`). |
| when_running_testsystem_06_modified_setting_table_parameter_values :: should_produce_correct_result_without_changing_table_parameter | NO | Already in C# (`when_running_testsystem_06_modified_setting_table_parameter_values`). |
| when_running_testsystem_06_modified_setting_table_parameter_values :: should_produce_correct_result_with_changing_table_parameter | NO | Already in C# (`when_running_testsystem_06_modified_setting_table_parameter_values`). |
| when_running_testsystem_06_V4_modified_setting_parameter_values_and_initial_values :: should_produce_correct_result | NO | Integration test (V4 schema), harness not available. |
| when_running_testsystem_06_V4_modified_setting_table_parameter_values :: should_produce_correct_result_without_changing_table_parameter | NO | Integration test (V4 schema), harness not available. |
| when_running_testsystem_06_V4_modified_setting_table_parameter_values :: should_produce_correct_result_with_changing_table_parameter | NO | Integration test (V4 schema), harness not available. |
| when_running_testsystem_06_new_schema_setting_all_parameters_as_variable :: should_produce_correct_result | NO | Integration test, harness not available. |
| when_running_pksim_input_01 :: should_perform_simulation_run | NO | Integration test, harness not available. |
| when_running_pksim_input_MultiApp_2_dense :: should_perform_simulation_run | NO | Integration test, harness not available. |
| when_running_pksim_input_MultiApp_2_band :: should_perform_simulation_run | NO | Integration test, harness not available. |
| when_running_pkmodelcore_case_study_01 :: mass_balance_at_t0_should_be_ok | NO | Already in C# (`when_running_pkmodelcore_case_study`). |
| when_running_pkmodelcore_case_study_01 :: mass_balance_at_tEnd_should_be_ok | NO | Already in C# (`when_running_pkmodelcore_case_study`). |
| when_running_pkmodelcore_case_study_01 :: amount_observer_for_arterial_blood_plasma_A_should_return_correct_values | NO | Already in C# (`when_running_pkmodelcore_case_study`). |
| when_running_pkmodelcore_case_study_01_with_scalefactor :: mass_balance_at_t0_and_at_tEnd_should_be_ok | NO | Already in C# (`when_running_pkmodelcore_case_study_with_scale_factor`). |
| when_running_pkmodelcore_case_study_01_with_scalefactor :: amount_observer_for_arterial_blood_plasma_A_should_return_correct_values | NO | Already in C# (`when_running_pkmodelcore_case_study_with_scale_factor`). |
| when_running_pkmodelcore_case_study_02 :: mass_balance_at_t0_and_at_tEnd_should_be_ok | NO | Integration test, harness not available. |
| when_running_test4model_reduced02 :: should_perform_simulation_run | NO | Integration test, harness not available. |
| when_running_test4model_reduced02 :: should_redim_variables_and_observers_according_to_is_persistant_flag | NO | Integration test, harness not available. |
| when_loading_from_file_new_schema :: should_be_loaded_from_file | NO | Integration test, harness not available. |
| when_running_below_abstol_test :: all_variable_values_below_abstol_should_be_zero | NO | Already in C# (`when_running_below_absolute_tolerance_test`). |
| when_running_AdultPopulation_sim :: should_perform_simulation_run | NO | Integration test, harness not available. |
| when_running_oral_table_01 :: should_perform_simulation_run | NO | Integration test, harness not available. |
| when_loading_from_file_with_infinity_values :: should_be_loaded_from_file | NO | Integration test, harness not available. |
| when_running_IV_EHC :: start_of_gallbladder_refilling_should_be_in_the_switch_startpoints_list | NO | Integration test, harness not available. |
| when_running_Growing_const_tables :: should_perform_simulation_run | NO | Integration test, harness not available. |
| when_running_simulation_with_persistable_parameters :: should_perform_simulation_run_and_return_persistable_parameters_as_observers | NO | Already in C# (`when_running_simulation_with_persistable_parameters`). |
| when_loading_from_file_with_table_formulas :: should_return_table_formula_infos | NO | Already in C# (`when_loading_simulation_with_table_formulas`). |
| when_loading_solver_error_testmodel :: should_load_and_finalize_simulation | NO | Integration test, harness not available. |
| when_changing_ehc_start_time :: changing_ehc_start_time_should_alter_simulation_results | NO | Already in C# (`when_changing_ehc_start_time`). |
| when_loading_from_old_xml_file :: xml_version_should_be_set_to_the_old_version | NO | Managed XML-API test (uses .NET wrapper); out of scope for native gtest. |
| when_loading_from_new_xml_file :: xml_version_should_be_set_to_the_new_version | NO | Managed XML-API test; out of scope for native gtest. |
| when_changing_species_initial_values :: should_update_species_initial_values_in_the_simulation_xml_node | NO | Managed XML-API test; out of scope for native gtest. |
| when_exporting_bcm_platelet_to_matlab :: should_export_to_matlab | NO | Already in C# (`when_exporting_bcm_platelet_to_matlab`). |
| when_loading_simualtion_which_is_not_schema_conform :: should_throw_a_BTS_exception | NO | Managed test (expects a managed exception type); out of scope for native gtest. |
| when_running_simulation_with_if_formula_in_event_condition :: should_perform_simulation_run | NO | Integration test, harness not available. |
| when_running_simulation_returning_not_allowed_negative_values :: should_perform_simulation_run_without_negative_values_check_and_throw_an_exception_with_negative_values_check | NO | Already in C# (`when_running_simulation_returning_not_allowed_negative_values`). |
| when_running_simulation_with_events_simultaneously_increasing_a_variable :: should_perform_all_events | NO | Already in C# (`when_running_simulation_with_events_simultaneously_increasing_a_variable`). |
| when_solving_cvsRoberts_FSA_dns_with_sensitivity_Sensitivity_RHS_function_not_set :: should_solve_example_system_and_return_correct_sensitivity_values | NO | Already in C# (`when_solving_cvsRoberts_FSA_dns_with_sensitivity_Sensitivity_RHS_function_not_set`). |
| when_solving_cvsRoberts_FSA_dns_with_sensitivity_Sensitivity_RHS_function_not_set :: should_solve_example_system_and_return_correct_sensitivity_values_by_entity_path | NO | Already in C# (`when_solving_cvsRoberts_FSA_dns_with_sensitivity_Sensitivity_RHS_function_not_set`). |
| when_running_simulation_with_almost_equal_output_times :: should_remove_duplicate_time_points_according_to_comparison | NO | Already in C# (`when_running_simulation_with_almost_equal_output_times`). |
| when_getting_output_schema :: should_retrieve_correct_output_schema | NO | Managed API test; native `OutputSchemaSpecs` covers schema behaviour separately. |
| when_setting_output_schema :: should_retrieve_output_time_vector_matching_the_new_schema | NO | Managed API test; out of scope for native gtest. |
| when_solving_A_exp_minus_kT_with_sensitivity :: should_solve_example_system_and_return_correct_sensitivity_values | NO | Already in C# (`when_solving_A_exp_minus_kT_with_sensitivity`). |
| when_calculating_sensitivity_of_persistable_parameter :: should_calculate_sensitivity_values_of_persistable_parameter | NO | Already in C# (`when_calculating_sensitivity_of_persistable_parameter`). |
| when_running_GIM_Table_Infusion_starting_at_1000_dense :: should_perform_simulation_run | NO | Integration test, harness not available. |
| when_running_GIM_Table_Infusion_starting_at_1000_band :: should_perform_simulation_run | NO | Integration test, harness not available. |
| when_running_GIM_model_with_negative_Mealtime_offset :: should_perform_simulation_run | NO | Integration test, harness not available. |
| when_changing_output_schema :: should_update_output_schema_in_the_simulation_xml_string | NO | Managed XML-API test; out of scope for native gtest. |
| when_getting_simulation_xml_string :: should_return_xml_string_if_keep_xml_option_was_set_to_true | NO | Managed XML-API test; out of scope for native gtest. |
| when_getting_simulation_xml_string :: should_fail_to_return_xml_string_if_keep_xml_option_was_set_to_false | NO | Managed XML-API test; out of scope for native gtest. |
| when_running_simulation_with_ph_solubility_table :: should_perform_simulation_run | NO | Integration test, harness not available. |
| when_running_simulation_with_ph_solubility_table_zero :: should_perform_simulation_run | NO | Integration test, harness not available. |
| when_running_simulation_with_ph_solubility_table_const :: should_perform_simulation_run | NO | Integration test, harness not available. |
| when_getting_all_used_parameters_when_identify_used_parameters_set_to_true :: should_return_only_used_parameters_via_native_interface | NO | Already in C# (`when_getting_all_used_parameters_when_identify_used_parameters_set_to_true`). |
| when_getting_all_used_parameters_when_identify_used_parameters_set_to_true :: should_return_only_used_parameters_via_managed_interface | NO | Managed-interface test; already in C#. |
| when_getting_all_used_parameters_when_identify_used_parameters_set_to_false :: should_return_all_parameters_via_native_interface | NO | Already in C# (`when_getting_all_used_parameters_when_identify_used_parameters_set_to_false`). |
| when_getting_all_used_parameters_when_identify_used_parameters_set_to_false :: should_return_all_parameters_via_managed_interface | NO | Managed-interface test; already in C#. |
| when_setting_scale_factor_to_one :: should_solve_the_system_correctly | NO | Already in C# (`when_setting_scale_factor_to_one`). |

</details> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader automated test coverage for formulas, parameters, simulation timing, and output time points.

* **Bug Fixes**
  * Improved build reliability on macOS and Windows by updating checkout and setup steps in CI.
  * Added Windows process initialization needed for native tests to run consistently.

* **Tests**
  * Expanded native test suites with new cases for table-based formulas, offsets, x-arguments, and output schema handling.
  * Added coverage for core simulation task timing and matrix ordering behavior.

* **Chores**
  * Updated CI tooling versions used during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->